### PR TITLE
Support elliptical mask shapes

### DIFF
--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -463,12 +463,12 @@ class ModelConfig(Config):
 
                         if "radius" in mask_options:
                             radius = mask_options["radius"][n]
-                            mask_outer = mask_util.mask_center_2d(
+                            mask = mask_util.mask_azimuthal(
+                                util.image2array(x_coords),
+                                util.image2array(y_coords),
                                 self.deflector_center_ra + offset[0],
                                 self.deflector_center_dec + offset[1],
                                 radius,
-                                util.image2array(x_coords),
-                                util.image2array(y_coords),
                             )
                         elif (
                             "a" in mask_options
@@ -478,7 +478,9 @@ class ModelConfig(Config):
                             a = mask_options["a"][n]
                             b = mask_options["b"][n]
                             angle = mask_options["angle"][n]
-                            mask_outer = mask_util.mask_ellipse(
+                            mask = mask_util.mask_ellipse(
+                                util.image2array(x_coords),
+                                util.image2array(y_coords),
                                 self.deflector_center_ra + offset[0],
                                 self.deflector_center_dec + offset[1],
                                 a,
@@ -497,16 +499,15 @@ class ModelConfig(Config):
                             if self.settings["mask"]["extra_regions"] is not None:
                                 for reg in self.settings["mask"]["extra_regions"][n]:
                                     extra_masked_regions.append(
-                                        mask_util.mask_center_2d(
+                                        1
+                                        - mask_util.mask_azimuthal(
+                                            util.image2array(x_coords),
+                                            util.image2array(y_coords),
                                             self.deflector_center_ra + reg[0],
                                             self.deflector_center_dec + reg[1],
                                             reg[2],
-                                            util.image2array(x_coords),
-                                            util.image2array(y_coords),
                                         )
                                     )
-
-                        mask = 1.0 - mask_outer
 
                         for extra_region in extra_masked_regions:
                             mask *= extra_region

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -452,24 +452,41 @@ class ModelConfig(Config):
                             mask_options["transform_matrix"][n]
                         )
                         num_pixel = mask_options["size"][n]
-                        radius = mask_options["radius"][n]
                         offset = mask_options["centroid_offset"][n]
 
                         coords = Coordinates(
                             transform_pix2angle, ra_at_xy_0, dec_at_xy_0
                         )
-
                         x_coords, y_coords = coords.coordinate_grid(
                             num_pixel, num_pixel
                         )
 
-                        mask_outer = mask_util.mask_center_2d(
-                            self.deflector_center_ra + offset[0],
-                            self.deflector_center_dec + offset[1],
-                            radius,
-                            util.image2array(x_coords),
-                            util.image2array(y_coords),
-                        )
+                        if "radius" in mask_options:
+                            radius = mask_options["radius"][n]
+                            mask_outer = mask_util.mask_center_2d(
+                                self.deflector_center_ra + offset[0],
+                                self.deflector_center_dec + offset[1],
+                                radius,
+                                util.image2array(x_coords),
+                                util.image2array(y_coords),
+                            )
+                        elif (
+                            "a" in mask_options
+                            and "b" in mask_options
+                            and "angle" in mask_options
+                        ):
+                            a = mask_options["a"][n]
+                            b = mask_options["b"][n]
+                            angle = mask_options["angle"][n]
+                            mask_outer = mask_util.ellipse(
+                                self.deflector_center_ra + offset[0],
+                                self.deflector_center_dec + offset[1],
+                                a,
+                                b,
+                                angle,
+                            )
+                        else:
+                            raise ValueError("Mask shape not properly specified!")
 
                         extra_masked_regions = []
                         try:

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -478,7 +478,7 @@ class ModelConfig(Config):
                             a = mask_options["a"][n]
                             b = mask_options["b"][n]
                             angle = mask_options["angle"][n]
-                            mask_outer = mask_util.ellipse(
+                            mask_outer = mask_util.mask_ellipse(
                                 self.deflector_center_ra + offset[0],
                                 self.deflector_center_dec + offset[1],
                                 a,

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -356,6 +356,33 @@ class TestModelConfig(object):
         assert masks3[1][5, 0:6].tolist() == [0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
         assert masks3[1][5, -6:].tolist() == [1.0, 1.0, 1.0, 1.0, 0.0, 0.0]
 
+        # test elliptical mask
+        config_elliptial_mask = deepcopy(self.config_1)
+        del config_elliptial_mask.settings["mask"]["radius"]
+
+        with pytest.raises(ValueError):
+            config_elliptial_mask.get_masks()
+
+        config_elliptial_mask.settings["mask"]["a"] = [1]
+
+        with pytest.raises(ValueError):
+            config_elliptial_mask.get_masks()
+
+        config_elliptial_mask.settings["mask"]["b"] = [0.5]
+
+        with pytest.raises(ValueError):
+            config_elliptial_mask.get_masks()
+
+        config_elliptial_mask.settings["mask"]["angle"] = [np.pi / 4.0]
+
+        masks_elliptical = config_elliptial_mask.get_masks()
+        assert len(masks_elliptical) == self.config_elliptial_mask.band_number
+        for n in range(self.config_elliptial_mask.band_number):
+            assert masks_elliptical[n].shape == (
+                self.config_elliptial_mask.settings["mask"]["size"][n],
+                self.config_elliptial_mask.settings["mask"]["size"][n],
+            )
+
     def test_get_kwargs_psf_iteration(self):
         """Test `get_psf_iteration` method.
 

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -376,11 +376,11 @@ class TestModelConfig(object):
         config_elliptial_mask.settings["mask"]["angle"] = [np.pi / 4.0]
 
         masks_elliptical = config_elliptial_mask.get_masks()
-        assert len(masks_elliptical) == self.config_elliptial_mask.band_number
-        for n in range(self.config_elliptial_mask.band_number):
+        assert len(masks_elliptical) == config_elliptial_mask.band_number
+        for n in range(config_elliptial_mask.band_number):
             assert masks_elliptical[n].shape == (
-                self.config_elliptial_mask.settings["mask"]["size"][n],
-                self.config_elliptial_mask.settings["mask"]["size"][n],
+                config_elliptial_mask.settings["mask"]["size"][n],
+                config_elliptial_mask.settings["mask"]["size"][n],
             )
 
     def test_get_kwargs_psf_iteration(self):


### PR DESCRIPTION
This PR adds the feature to specify elliptical masks. In the mask section of the config file, all three of "a", "b", and "angle" (see documentation of `lenstronomy.Util.mask_util.mask_ellipse()` for definitions) should be provided instead of "radius" for the elliptical mask to be created.