### PR TITLE
Make source_type non-optional parameter

### DIFF
--- a/dolphin/ai/modeler.py
+++ b/dolphin/ai/modeler.py
@@ -13,8 +13,14 @@ class Modeler(AI):
     """This class creates a configuration file from the output of the visual recognition
     model."""
 
-    def __init__(self, io_directory_path, source_type="quasar"):
-        """Initialize the Configure object."""
+    def __init__(self, io_directory_path, source_type):
+        """Initialize the Configure object.
+
+        :param io_directory_path: path to the input/output directory
+        :type io_directory_path: `str`
+        :param source_type: source type
+        :type source_type: `str`
+        """
         super(Modeler, self).__init__(io_directory_path)
         self._source_type = source_type
 


### PR DESCRIPTION
This pull request modifies the `Modeler` class in the `dolphin/ai/modeler.py` file to improve the initialization method by removing the default value for the `source_type` parameter and adding detailed docstrings for the parameters.

Initialization method improvements:

* [`dolphin/ai/modeler.py`](diffhunk://#diff-bda95bdca93750011e87413785de417cb38dc7220447cec7b745a0738a9da67dL16-R23): Removed the default value for the `source_type` parameter in the `__init__` method and added detailed docstrings for `io_directory_path` and `source_type` parameters.…nd add parameter descriptions