### PR TITLE
Bump version to 1.1.1 in __init__.py, pyproject.toml, and setup.py

### DIFF
--- a/dolphin/__init__.py
+++ b/dolphin/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 __author__ = "Anowar J. Shajib"
 __email__ = "ajshajib@gmail.com"
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "space-dolphin"
-version = "1.1.0"
+version = "1.1.1"
 description = "Automated pipeline for lens modeling based on lenstronomy"
 readme = "README.rst"
 license = "BSD-3-Clause"

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/ajshajib/dolphin",
-    version="1.1.0",
+    version="1.1.1",
     zip_safe=False,
 )


### PR DESCRIPTION
This pull request updates the version of the `dolphin` package from `1.1.0` to `1.1.1` across multiple files to ensure consistency and reflect the latest release.

Version updates:

* [`dolphin/__init__.py`](diffhunk://#diff-d29c193ffe58b8ed4dccfda7cfa2570fbf55111386bc2a0e115fe632f36df99dL4-R4): Updated the `__version__` attribute to `1.1.1`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Changed the `version` field under `[project]` to `1.1.1`.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L40-R40): Updated the `version` argument in the `setup()` function to `1.1.1`.