### PR TITLE
Fix mask indexing in get_mask_from_semantic_segmentation method

### DIFF
--- a/dolphin/ai/modeler.py
+++ b/dolphin/ai/modeler.py
@@ -301,10 +301,10 @@ class Modeler(AI):
         pixel_size = coordinate_system.pixel_width
         for i in range(mask.shape[0]):
             for j in range(mask.shape[1]):
-                if (i - galaxy_center_x_pixel) ** 2 + (
-                    j - galaxy_center_y_pixel
+                if (j - galaxy_center_x_pixel) ** 2 + (
+                    i - galaxy_center_y_pixel
                 ) ** 2 < (mask_radius_factor * theta_E_init / pixel_size) ** 2:
-                    mask[j, i] = 1
+                    mask[i, j] = 1
 
         return mask
 


### PR DESCRIPTION
This pull request includes a fix to the `get_mask_from_semantic_segmentation` function in `dolphin/ai/modeler.py`. The change corrects the indexing logic and ensures the mask is applied correctly in the loop.

Key change:

* [`dolphin/ai/modeler.py`](diffhunk://#diff-bda95bdca93750011e87413785de417cb38dc7220447cec7b745a0738a9da67dL304-R307): Fixed the order of indices in the conditional statement and the mask assignment to correctly reflect the intended coordinate system.