### PR TITLE
Feature/ai settings

### DIFF
--- a/dolphin/ai/modeler.py
+++ b/dolphin/ai/modeler.py
@@ -98,6 +98,7 @@ class Modeler(AI):
         clear_center=0.2,
         source_n_max=6,
         mask_radius_factor=2.5,
+        additional_settings=None,
     ):
         """Get configuration from the semantic segmentation output. This method
         currently works only for the single-band case.
@@ -144,6 +145,8 @@ class Modeler(AI):
         :type source_n_max: `int`
         :param mask_radius_factor: factor of initial Einstein radius estimate to set the circular mask radius
         :type mask_radius_factor: `float`
+        :param additional_settings: additional settings to be added to the configuration
+        :type additional_settings: `dict`
         :return: configuration
         :rtype: `dict`
         """
@@ -269,6 +272,10 @@ class Modeler(AI):
                     mask_radius_factor=mask_radius_factor,
                 ),
             )
+
+        if additional_settings is not None:
+            for key, value in additional_settings.items():
+                config[key] = value
 
         return config
 

--- a/test/test_ai/test_modeler.py
+++ b/test/test_ai/test_modeler.py
@@ -119,6 +119,12 @@ class TestModeler:
         for keyword in keywords:
             assert keyword in config
 
+        config = self.qso_modeler.get_configuration(
+            lens_system, "F814W", additional_settings={"new_key": "new_value"}
+        )
+        assert "new_key" in config
+        assert config["new_key"] == "new_value"
+
     def test_get_mask_from_semantic_segmentation(self):
         """Test `get_mask_from_semantic_segmentation` method.
 


### PR DESCRIPTION
This pull request adds support for injecting additional configuration settings into the `get_configuration` method of the `dolphin/ai/modeler.py` module. This makes the method more flexible by allowing users to pass custom settings, and includes corresponding updates to the method's docstring and its unit tests.

**Enhancements to configuration flexibility:**

* [`dolphin/ai/modeler.py`](diffhunk://#diff-bda95bdca93750011e87413785de417cb38dc7220447cec7b745a0738a9da67dR101): Added an `additional_settings` parameter to the `get_configuration` method, allowing users to merge custom key-value pairs into the configuration dictionary. Updated the docstring to document this new parameter. [[1]](diffhunk://#diff-bda95bdca93750011e87413785de417cb38dc7220447cec7b745a0738a9da67dR101) [[2]](diffhunk://#diff-bda95bdca93750011e87413785de417cb38dc7220447cec7b745a0738a9da67dR148-R149) [[3]](diffhunk://#diff-bda95bdca93750011e87413785de417cb38dc7220447cec7b745a0738a9da67dR276-R279)

**Testing improvements:**

* [`test/test_ai/test_modeler.py`](diffhunk://#diff-815debde8a1ea4e3caac244f3c225ea11bbb5ab1f687df19f77da892aacc22aeR122-R127): Added a test case to verify that custom settings passed via `additional_settings` are correctly added to the configuration.