### PR TITLE
Update configuration handling to merge additional settings safely

### DIFF
--- a/dolphin/ai/modeler.py
+++ b/dolphin/ai/modeler.py
@@ -275,7 +275,7 @@ class Modeler(AI):
 
         if additional_settings is not None:
             for key, value in additional_settings.items():
-                config[key] = value
+                config.setdefault(key, {}).update(value)
 
         return config
 

--- a/dolphin/ai/modeler.py
+++ b/dolphin/ai/modeler.py
@@ -275,7 +275,14 @@ class Modeler(AI):
 
         if additional_settings is not None:
             for key, value in additional_settings.items():
-                config.setdefault(key, {}).update(value)
+                if (
+                    key in config
+                    and isinstance(config[key], dict)
+                    and isinstance(value, dict)
+                ):
+                    config[key].update(value)
+                else:
+                    config[key] = value
 
         return config
 

--- a/test/test_ai/test_modeler.py
+++ b/test/test_ai/test_modeler.py
@@ -125,6 +125,14 @@ class TestModeler:
         assert "new_key" in config
         assert config["new_key"] == "new_value"
 
+        config = self.qso_modeler.get_configuration(
+            lens_system,
+            "F814W",
+            additional_settings={"lens_option": {"new_option": "new_value"}},
+        )
+        assert "lens_option" in config
+        assert config["lens_option"]["new_option"] == "new_value"
+
     def test_get_mask_from_semantic_segmentation(self):
         """Test `get_mask_from_semantic_segmentation` method.
 


### PR DESCRIPTION
This pull request makes a small but important change to how additional settings are merged into the configuration in the `get_configuration` function. The update ensures that if a key already exists in the `config` dictionary, its value (which is a dictionary) is updated rather than overwritten, which prevents loss of existing settings.

* Improved merging of `additional_settings` in `get_configuration`: Uses `setdefault` and `update` to preserve and extend existing nested dictionary values instead of overwriting them. (`dolphin/ai/modeler.py`)