### PR TITLE
Change default limits on Einstein radius prior

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -6,6 +6,13 @@ comment:                  # this is a top-level key
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: false        # [true :: must have a base report to post]
   require_head: true       # [true :: must have a head report to post]
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+        informational: false
 ignore:
   - "setup.py"
   - "test/*"

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -886,13 +886,17 @@ class ModelConfig(Config):
         multiple filters)"""
         return self.get_index_list("source_light")
 
-    def get_lens_model_params(self, theta_E_upper_factor=1.5, theta_E_lower_factor=0.3):
+    def get_lens_model_params(
+        self, theta_E_upper_factor=1.5, theta_E_lower_factor=0.3, theta_E_satellite=0.1
+    ):
         """Create `lens_params`.
 
         :param theta_E_upper_factor: Factor to multiply the initial Einstein radius for the upper bound
         :type theta_E_upper_factor: `float`
         :param theta_E_lower_factor: Factor to multiply the initial Einstein radius for the lower bound
         :type theta_E_lower_factor: `float`
+        :param theta_E_satellite: Initial guess for the satellite's Einstein radius, if exists.
+        :type theta_E_satellite: `float`
         :return:
         :rtype:
         """
@@ -926,9 +930,9 @@ class ModelConfig(Config):
                 center_y = self.settings["satellites"]["centroid_init"][
                     satellite_flags[i]
                 ][1]
-                theta_E_init = 0.1
-                theta_E_upper_limit = 1.0
-                theta_E_lower_limit = 0.01
+                theta_E_init = theta_E_satellite
+                theta_E_upper_limit = 5.0 * theta_E_satellite
+                theta_E_lower_limit = 0.2 * theta_E_satellite
 
             if model in ["SPEP", "PEMD", "EPL", "SIE"]:
                 if model == "SIE":

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -914,6 +914,9 @@ class ModelConfig(Config):
                     theta_E_init = self.settings["guess_params"]["lens"][0]["theta_E"]
                 except (NameError, KeyError):
                     theta_E_init = 1.0
+
+                theta_E_upper_limit = theta_E_upper_factor * theta_E_init
+                theta_E_lower_limit = theta_E_lower_factor * theta_E_init
             else:
                 # satellite
                 bound = self.settings["satellites"]["centroid_bound"]
@@ -924,6 +927,8 @@ class ModelConfig(Config):
                     satellite_flags[i]
                 ][1]
                 theta_E_init = 0.1
+                theta_E_upper_limit = 1.0
+                theta_E_lower_limit = 0.01
 
             if model in ["SPEP", "PEMD", "EPL", "SIE"]:
                 if model == "SIE":
@@ -953,7 +958,7 @@ class ModelConfig(Config):
 
                 lower.append(
                     {
-                        "theta_E": theta_E_lower_factor * theta_E_init,
+                        "theta_E": theta_E_lower_limit,
                         "e1": -0.5,
                         "e2": -0.5,
                         "gamma": 1.3,
@@ -964,7 +969,7 @@ class ModelConfig(Config):
 
                 upper.append(
                     {
-                        "theta_E": theta_E_upper_factor * theta_E_init,
+                        "theta_E": theta_E_upper_limit,
                         "e1": 0.5,
                         "e2": 0.5,
                         "gamma": 2.8,
@@ -996,14 +1001,14 @@ class ModelConfig(Config):
                 )
                 lower.append(
                     {
-                        "theta_E": theta_E_lower_factor * theta_E_init,
+                        "theta_E": theta_E_lower_limit,
                         "center_x": center_x - bound,
                         "center_y": center_y - bound,
                     }
                 )
                 upper.append(
                     {
-                        "theta_E": theta_E_upper_factor * theta_E_init,
+                        "theta_E": theta_E_upper_limit,
                         "center_x": center_x + bound,
                         "center_y": center_y + bound,
                     }

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -886,9 +886,13 @@ class ModelConfig(Config):
         multiple filters)"""
         return self.get_index_list("source_light")
 
-    def get_lens_model_params(self):
+    def get_lens_model_params(self, theta_E_upper_factor=1.5, theta_E_lower_factor=0.3):
         """Create `lens_params`.
 
+        :param theta_E_upper_factor: Factor to multiply the initial Einstein radius for the upper bound
+        :type theta_E_upper_factor: `float`
+        :param theta_E_lower_factor: Factor to multiply the initial Einstein radius for the lower bound
+        :type theta_E_lower_factor: `float`
         :return:
         :rtype:
         """
@@ -949,7 +953,7 @@ class ModelConfig(Config):
 
                 lower.append(
                     {
-                        "theta_E": 0.3,
+                        "theta_E": theta_E_lower_factor * theta_E_init,
                         "e1": -0.5,
                         "e2": -0.5,
                         "gamma": 1.3,
@@ -960,7 +964,7 @@ class ModelConfig(Config):
 
                 upper.append(
                     {
-                        "theta_E": 3.0,
+                        "theta_E": theta_E_upper_factor * theta_E_init,
                         "e1": 0.5,
                         "e2": 0.5,
                         "gamma": 2.8,
@@ -992,14 +996,14 @@ class ModelConfig(Config):
                 )
                 lower.append(
                     {
-                        "theta_E": 0.0,
+                        "theta_E": theta_E_lower_factor * theta_E_init,
                         "center_x": center_x - bound,
                         "center_y": center_y - bound,
                     }
                 )
                 upper.append(
                     {
-                        "theta_E": 1.0,
+                        "theta_E": theta_E_upper_factor * theta_E_init,
                         "center_x": center_x + bound,
                         "center_y": center_y + bound,
                     }


### PR DESCRIPTION
**Lens Model Parameter Configuration:**

* The `get_lens_model_params` method in `dolphin/processor/config.py` now accepts two optional parameters: `theta_E_upper_factor` and `theta_E_lower_factor`, allowing customization of the upper and lower bounds for the Einstein radius.
* All hardcoded values for `theta_E` in the lower and upper bounds are replaced with values computed using the provided factors and the initial `theta_E`, enhancing flexibility and adaptability for different modeling scenarios. [[1]](diffhunk://#diff-a163ed39c4f0930fbf6ef406764acfbcebf737c5128c4aebdc4b02dd9cdd7599L952-R956) [[2]](diffhunk://#diff-a163ed39c4f0930fbf6ef406764acfbcebf737c5128c4aebdc4b02dd9cdd7599L963-R967) [[3]](diffhunk://#diff-a163ed39c4f0930fbf6ef406764acfbcebf737c5128c4aebdc4b02dd9cdd7599L995-R1006)

**Code Coverage Configuration:**

* The `codecov.yaml` file is updated to require 100% patch coverage for pull requests, ensuring that all new or changed code is fully tested before merging.