### PR TITLE
Add Astrometric Uncertainty Sampling & Framework for Future Special Parameters.

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -82,7 +82,7 @@ Model Section
       - Example:
 
         .. code-block:: yaml
-          special: ["ASTROMETRIC_UNCERTAINTY"]
+          special: ["astrometric_uncertainty"]
 
 Satellites Section
 ------------------

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -76,6 +76,14 @@ Model Section
 
            point_source: ["LENSED_POSITION"]
 
+    - ``special``: *(Optional)* List of special parameter types.
+
+      - Type: ``list of strings``
+      - Example:
+
+        .. code-block:: yaml
+          special: ["ASTROMETRIC_UNCERTAINTY"]
+
 Satellites Section
 ------------------
 
@@ -256,6 +264,32 @@ Source Light Options
         .. code-block:: yaml
 
            n_max: [2, 4]
+
+Special Options
+---------------
+
+- ``special_option``: Initialization of special parameters.
+
+  - Suboptions:
+
+    ``delta_x_image``: Initial spread from point source centroid.
+    ``delta_y_image``: Initial spread from point source centroid.
+
+      - Type: ``array of floats corresponding to the number of point sources``
+      - Example:
+
+        .. code-block:: yaml
+          delta_x_image: [0.0, 0.0]
+          delta_y_image: [0.0, 0.0]
+    ``delta_image_lower``: Lower bound in spread of point source centroid sampler.
+    ``delta_image_uppwer``: Upper bound in spread of point source centroid sampler.
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+          delta_image_lower: -0.004
+          delta_image_upper: 0.004
 
 Numeric Options
 ---------------

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1400,7 +1400,13 @@ class ModelConfig(Config):
         special_list = self.get_special_list()
 
         if len(special_list) == 0:
-            return [[], [], [], [], []]
+            return [{}, {}, {}, {}, {}]
+
+        init = {}
+        sigma = {}
+        lower = {}
+        upper = {}
+        fixed = {}
 
         for i, model in enumerate(special_list):
             if model == "ASTROMETRIC_UNCERTAINTY":
@@ -1410,36 +1416,37 @@ class ModelConfig(Config):
                     )
                 )
 
-                init = {
+                init.update({
                     "delta_x_image": np.array(self.settings["special_option"]["delta_x_image"]),
                     "delta_y_image": np.array(self.settings["special_option"]["delta_y_image"]),
-                }
+                })
 
-                sigma = {
+                sigma.update({
                     "delta_x_image": 0.004 * np.ones(num_point_sources),
                     "delta_y_image": 0.004 * np.ones(num_point_sources),
-                }
+                })
 
-                lower = {
+                lower.update({
                     "delta_x_image": self.settings["special_option"]["delta_image_lower"] 
                     * np.ones(num_point_sources),
                     "delta_y_image": self.settings["special_option"]["delta_image_lower"] 
                     * np.ones(num_point_sources),
-                }
+                })
 
-                upper = {
+                upper.update({
                     "delta_x_image": self.settings["special_option"]["delta_image_upper"] 
                     * np.ones(num_point_sources),
                     "delta_y_image": self.settings["special_option"]["delta_image_upper"] 
                     * np.ones(num_point_sources),
-                }
+                })
 
-                fixed = {}
+                fixed.update({})
             
             else:
                 raise ValueError(f"{model} not supported!")
 
-        return [init, sigma, fixed, lower, upper]
+        params = [init, sigma, fixed, lower, upper]
+        return params
 
     def fill_in_fixed_from_settings(self, component, fixed_list):
         """Fill in fixed values from settings for lens, source light and lens light.

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1466,9 +1466,6 @@ class ModelConfig(Config):
 
                 fixed.update({})
 
-            else:
-                raise ValueError(f"{model} not supported!")
-
         params = [init, sigma, fixed, lower, upper]
         return params
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -934,7 +934,8 @@ class ModelConfig(Config):
                 special_list.append("ASTROMETRIC_UNCERTAINTY")
                 return special_list
             elif self.settings["model"]["special"] != "ASTROMETRIC_UNCERTAINTY":
-                raise ValueError(f"{self.settings["model"]["special"]} not supported")
+                special = self.settings["model"]["special"]
+                raise ValueError(f"{special} not supported")
         else:
             return []
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -924,16 +924,16 @@ class ModelConfig(Config):
     def get_special_list(self):
         """Return `special_list`.
 
-        :return:
-        :rtype:
+        :return: special_list
+        :rtype: list
         """
         special_list = []
 
         if "special" in self.settings["model"]:
-            if "ASTROMETRIC_UNCERTAINTY" in self.settings["model"]["special"]:
-                special_list.append("ASTROMETRIC_UNCERTAINTY")
+            if "astrometric_uncertainty" in self.settings["model"]["special"]:
+                special_list.append("astrometric_uncertainty")
                 return special_list
-            elif self.settings["model"]["special"] != "ASTROMETRIC_UNCERTAINTY":
+            elif self.settings["model"]["special"] != "astrometric_uncertainty":
                 special = self.settings["model"]["special"]
                 raise ValueError(f"{special} not supported")
         else:
@@ -1397,6 +1397,11 @@ class ModelConfig(Config):
         return params
 
     def get_special_params(self):
+        """Create `special_params`.
+
+        :return: params
+        :rtype: list of dict
+        """
 
         special_list = self.get_special_list()
 
@@ -1410,7 +1415,7 @@ class ModelConfig(Config):
         fixed = {}
 
         for i, model in enumerate(special_list):
-            if model == "ASTROMETRIC_UNCERTAINTY":
+            if model == "astrometric_uncertainty":
                 num_point_sources = len(
                     np.array(self.settings["special_option"]["delta_x_image"])
                 )

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -942,7 +942,7 @@ class ModelConfig(Config):
     def get_index_list(self, light_type="lens_light"):
         """Create list with of index for the different light profiles (for multiple
         filters)
-        
+
         :param light_type: Key specifying which light model to use from ``self.settings["model"]``
         :type light_type: str
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -941,7 +941,14 @@ class ModelConfig(Config):
 
     def get_index_list(self, light_type="lens_light"):
         """Create list with of index for the different light profiles (for multiple
-        filters)"""
+        filters)
+        
+        :param light_type: Key specifying which light model to use from ``self.settings["model"]``
+        :type light_type: str
+
+        :return: index_list
+        :rtype: list[list]
+        """
         index_list = []
 
         if light_type in self.settings["model"]:

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -928,7 +928,7 @@ class ModelConfig(Config):
         :rtype:
         """
         special_list = []
-        
+
         if "special" in self.settings["model"]:
             if "ASTROMETRIC_UNCERTAINTY" in self.settings["model"]["special"]:
                 special_list.append("ASTROMETRIC_UNCERTAINTY")
@@ -1394,7 +1394,7 @@ class ModelConfig(Config):
 
         params = [init, sigma, fixed, lower, upper]
         return params
-    
+
     def get_special_params(self):
 
         special_list = self.get_special_list()
@@ -1411,37 +1411,55 @@ class ModelConfig(Config):
         for i, model in enumerate(special_list):
             if model == "ASTROMETRIC_UNCERTAINTY":
                 num_point_sources = len(
-                    np.array(
-                    self.settings["special_option"]["delta_x_image"]
-                    )
+                    np.array(self.settings["special_option"]["delta_x_image"])
                 )
 
-                init.update({
-                    "delta_x_image": np.array(self.settings["special_option"]["delta_x_image"]),
-                    "delta_y_image": np.array(self.settings["special_option"]["delta_y_image"]),
-                })
+                init.update(
+                    {
+                        "delta_x_image": np.array(
+                            self.settings["special_option"]["delta_x_image"]
+                        ),
+                        "delta_y_image": np.array(
+                            self.settings["special_option"]["delta_y_image"]
+                        ),
+                    }
+                )
 
-                sigma.update({
-                    "delta_x_image": 0.004 * np.ones(num_point_sources),
-                    "delta_y_image": 0.004 * np.ones(num_point_sources),
-                })
+                sigma.update(
+                    {
+                        "delta_x_image": 0.004 * np.ones(num_point_sources),
+                        "delta_y_image": 0.004 * np.ones(num_point_sources),
+                    }
+                )
 
-                lower.update({
-                    "delta_x_image": self.settings["special_option"]["delta_image_lower"] 
-                    * np.ones(num_point_sources),
-                    "delta_y_image": self.settings["special_option"]["delta_image_lower"] 
-                    * np.ones(num_point_sources),
-                })
+                lower.update(
+                    {
+                        "delta_x_image": self.settings["special_option"][
+                            "delta_image_lower"
+                        ]
+                        * np.ones(num_point_sources),
+                        "delta_y_image": self.settings["special_option"][
+                            "delta_image_lower"
+                        ]
+                        * np.ones(num_point_sources),
+                    }
+                )
 
-                upper.update({
-                    "delta_x_image": self.settings["special_option"]["delta_image_upper"] 
-                    * np.ones(num_point_sources),
-                    "delta_y_image": self.settings["special_option"]["delta_image_upper"] 
-                    * np.ones(num_point_sources),
-                })
+                upper.update(
+                    {
+                        "delta_x_image": self.settings["special_option"][
+                            "delta_image_upper"
+                        ]
+                        * np.ones(num_point_sources),
+                        "delta_y_image": self.settings["special_option"][
+                            "delta_image_upper"
+                        ]
+                        * np.ones(num_point_sources),
+                    }
+                )
 
                 fixed.update({})
-            
+
             else:
                 raise ValueError(f"{model} not supported!")
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -921,6 +921,23 @@ class ModelConfig(Config):
         else:
             return []
 
+    def get_special_list(self):
+        """Return `special_list`.
+
+        :return:
+        :rtype:
+        """
+        special_list = []
+        
+        if "special" in self.settings["model"]:
+            if "ASTROMETRIC_UNCERTAINTY" in self.settings["model"]["special"]:
+                special_list.append("ASTROMETRIC_UNCERTAINTY")
+                return special_list
+            elif self.settings["model"]["special"] != "ASTROMETRIC_UNCERTAINTY":
+                raise ValueError(f"{self.settings["model"]["special"]} not supported")
+        else:
+            return []
+
     def get_index_list(self, light_type="lens_light"):
         """Create list with of index for the different light profiles (for multiple
         filters)"""
@@ -1377,6 +1394,52 @@ class ModelConfig(Config):
 
         params = [init, sigma, fixed, lower, upper]
         return params
+    
+    def get_special_params(self):
+
+        special_list = self.get_special_list()
+
+        if len(special_list) == 0:
+            return [[], [], [], [], []]
+
+        for i, model in enumerate(special_list):
+            if model == "ASTROMETRIC_UNCERTAINTY":
+                num_point_sources = len(
+                    np.array(
+                    self.settings["special_option"]["delta_x_image"]
+                    )
+                )
+
+                init = {
+                    "delta_x_image": np.array(self.settings["special_option"]["delta_x_image"]),
+                    "delta_y_image": np.array(self.settings["special_option"]["delta_y_image"]),
+                }
+
+                sigma = {
+                    "delta_x_image": 0.004 * np.ones(num_point_sources),
+                    "delta_y_image": 0.004 * np.ones(num_point_sources),
+                }
+
+                lower = {
+                    "delta_x_image": self.settings["special_option"]["delta_image_lower"] 
+                    * np.ones(num_point_sources),
+                    "delta_y_image": self.settings["special_option"]["delta_image_lower"] 
+                    * np.ones(num_point_sources),
+                }
+
+                upper = {
+                    "delta_x_image": self.settings["special_option"]["delta_image_upper"] 
+                    * np.ones(num_point_sources),
+                    "delta_y_image": self.settings["special_option"]["delta_image_upper"] 
+                    * np.ones(num_point_sources),
+                }
+
+                fixed = {}
+            
+            else:
+                raise ValueError(f"{model} not supported!")
+
+        return [init, sigma, fixed, lower, upper]
 
     def fill_in_fixed_from_settings(self, component, fixed_list):
         """Fill in fixed values from settings for lens, source light and lens light.
@@ -1423,6 +1486,7 @@ class ModelConfig(Config):
             "source_model": self.get_source_light_model_params(),
             "lens_light_model": self.get_lens_light_model_params(),
             "point_source_model": self.get_point_source_params(),
+            "special": self.get_special_params(),
             # 'cosmography': []
         }
 

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -642,7 +642,7 @@ class TestModelConfig(object):
         config = deepcopy(self.config_3)
         config.settings["model"]["special"] = ["INVALID"]
         with pytest.raises(ValueError):
-            self.config_3.get_special_list()
+            config.get_special_list()
 
     def test_get_lens_model_params(self):
         """Test `get_lens_model_params` method.

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -625,14 +625,14 @@ class TestModelConfig(object):
 
     def test_get_special_list(self):
         """Test `get_special_list` method."""
-        
+
         # Test 1: ensure consistency of special models
         # if specified in config file
         config = deepcopy(self.config_5)
         config.settings["model"]["special"] = ["astrometric_uncertainty"]
         assert config.get_special_list() == ["astrometric_uncertainty"]
 
-        # Test 2: ensure special list is empty if not 
+        # Test 2: ensure special list is empty if not
         # specified in the config file
         config = deepcopy(self.config_1)
         assert config.get_special_list() == []

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -792,13 +792,6 @@ class TestModelConfig(object):
 
         assert params == [{}, {}, {}, {}, {}]
 
-        # Test 3: ensure error message prints if special
-        # type is not supported
-        config = deepcopy(self.config_3)
-        config.settings["model"]["special"] = ["INVALID"]
-        with pytest.raises(ValueError):
-            config.get_special_params()
-
     def test_fill_in_fixed_from_settings(self):
         """Test `fill_in_fixed_from_settings` method.
 

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -623,6 +623,27 @@ class TestModelConfig(object):
         config = deepcopy(self.config_5)
         assert config.get_point_source_model_list() == ["LENSED_POSITION"]
 
+    def test_get_special_list(self):
+        """Test `get_special_list` method."""
+        
+        # Test 1: ensure consistency of special models
+        # if specified in config file
+        config = deepcopy(self.config_5)
+        config.settings["model"]["special"] = ["astrometric_uncertainty"]
+        assert config.get_special_list() == ["astrometric_uncertainty"]
+
+        # Test 2: ensure special list is empty if not 
+        # specified in the config file
+        config = deepcopy(self.config_1)
+        assert config.get_special_list() == []
+
+        # Test 3: ensure error message prints if special
+        # type is not supported
+        config = deepcopy(self.config_3)
+        config.settings["model"]["special"] = ["INVALID"]
+        with pytest.raises(ValueError):
+            self.config_3.get_special_list()
+
     def test_get_lens_model_params(self):
         """Test `get_lens_model_params` method.
 
@@ -723,6 +744,60 @@ class TestModelConfig(object):
         config3.settings["source_light_option"]["n_max"] = 2
         config3.get_source_light_model_params()
         assert config3.settings["source_light_option"]["n_max"] == [2, 2]
+
+    def test_get_special_params(self):
+        """Test `get_special_params` method."""
+
+        # Test 1: ensure consistency of astrometric uncertainty params
+        # if specified in config file
+        config = deepcopy(self.config_5)
+
+        config.settings["model"]["special"] = ["astrometric_uncertainty"]
+        config.settings["special_option"] = {
+            "delta_x_image": [0.004, 0.004, 0.004, 0.004],
+            "delta_y_image": [0.004, 0.004, 0.004, 0.004],
+            "delta_image_lower": -0.004,
+            "delta_image_upper": 0.004,
+        }
+
+        params = config.get_special_params()
+
+        init, sigma, fixed, lower, upper = params
+
+        npt.assert_array_equal(
+            init["delta_x_image"], np.array([0.004, 0.004, 0.004, 0.004])
+        )
+        npt.assert_array_equal(
+            init["delta_y_image"], np.array([0.004, 0.004, 0.004, 0.004])
+        )
+
+        assert np.all(sigma["delta_x_image"] == 0.004)
+        assert np.all(sigma["delta_y_image"] == 0.004)
+        assert len(sigma["delta_x_image"]) == 4
+        assert len(sigma["delta_y_image"]) == 4
+
+        assert np.all(lower["delta_x_image"] == -0.004)
+        assert np.all(upper["delta_x_image"] == 0.004)
+
+        assert np.all(lower["delta_y_image"] == -0.004)
+        assert np.all(upper["delta_y_image"] == 0.004)
+
+        assert fixed == {}
+
+        # Test 2: ensure special params is empty list of dictionaries
+        # if not specified in the config file
+        config = deepcopy(self.config_1)
+
+        params = config.get_special_params()
+
+        assert params == [{}, {}, {}, {}, {}]
+
+        # Test 3: ensure error message prints if special
+        # type is not supported
+        config = deepcopy(self.config_3)
+        config.settings["model"]["special"] = ["INVALID"]
+        with pytest.raises(ValueError):
+            config.get_special_params()
 
     def test_fill_in_fixed_from_settings(self):
         """Test `fill_in_fixed_from_settings` method.


### PR DESCRIPTION
This pull request implements the astrometric uncertainty ``special`` parameter type, as well as creates a foundation for future ``special`` parameter types to be included. In ``Lenstronomy``, the astrometric uncertainty parameters set the scale over which the point source centroid varies relative to the optimized point source center, preventing unrealistically tight posteriors. Additionally, the documentation has been updated accordingly with the new information for astrometric sampling.