### PR TITLE
Feature/nautilus

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -448,7 +448,7 @@ Fitting Options
 
            sampling: true
 
-    - ``sampler``: The sampler to use for sampling. Currently, only ``emcee`` is fully supported.
+    - ``sampler``: The sampler to use for sampling. Supported samplers are ``emcee`` and ``Nautilus``.
 
       - Type: ``string``
       - Example:
@@ -457,9 +457,67 @@ Fitting Options
 
            sampler: emcee
 
-    - ``sampler_settings``: Settings for the sampler.
+    - ``sampler_settings``: Settings for the sampler. For full documentation of parameters, refer to the `lenstronomy sampler documentation <https://lenstronomy.readthedocs.io/en/latest/lenstronomy.Sampling.Samplers.html>`_ and the `Nautilus documentation <https://nautilus-sampler.readthedocs.io>`_.
 
       - Suboptions:
+
+        **Recommended Nautilus options:**
+
+        - ``n_live``: Number of live points used by the nested sampler.
+
+          - Type: ``integer``
+          - Example:
+
+            .. code-block:: yaml
+
+               n_live: 2000
+
+        - ``n_eff``: Minimum targeted effective sample size. The algorithm will sample from the shells until this is reached.
+
+          - Type: ``float``
+          - Example:
+
+            .. code-block:: yaml
+
+               n_eff: 10000.0
+
+        - ``verbose``: If True, prints detailed information about the sampler's progress.
+
+          - Type: ``boolean``
+          - Example:
+
+            .. code-block:: yaml
+
+               verbose: true
+
+        - ``pass_dict``: Whether to pass dictionaries to the likelihood. Usually set to ``false`` for better performance.
+
+          - Type: ``boolean``
+          - Example:
+
+            .. code-block:: yaml
+
+               pass_dict: false
+
+        - ``filepath``: Path to a file (``.h5`` or ``.hdf5``) where Nautilus will save its internal state for checkpointing.
+
+          - Type: ``string``
+          - Example:
+
+            .. code-block:: yaml
+
+               filepath: "nautilus_checkpoint.hdf5"
+
+        - ``resume``: Whether to resume a run from the file specified in ``filepath``.
+
+          - Type: ``boolean``
+          - Example:
+
+            .. code-block:: yaml
+
+               resume: true
+
+        **Emcee-specific options:**
 
         - ``n_burn``: Number of burn-in steps.
 
@@ -491,6 +549,54 @@ Fitting Options
         - ``init_samples``: *(Optional)* Initial samples for walkers.
           
           - Type: ``list of lists of floats``
+
+        - ``n_walkers``: *(Optional)* Number of walkers of emcee. If set, this overwrites the ``walkerRatio`` input.
+
+          - Type: ``integer``
+          - Example:
+
+            .. code-block:: yaml
+
+               n_walkers: 100
+
+        - ``sigma_scale``: *(Optional)* Scaling of the initial parameter spread relative to the width in the initial settings. Default is 1.0.
+
+          - Type: ``float``
+          - Example:
+
+            .. code-block:: yaml
+
+               sigma_scale: 1.0
+
+        - ``threadCount``: *(Optional)* Number of CPU threads to use for multiprocessing.
+
+          - Type: ``integer``
+          - Example:
+
+            .. code-block:: yaml
+
+               threadCount: 4
+
+        - ``re_use_samples``: *(Optional)* If True and ``init_samples`` is provided, re-uses the samples described.
+
+          - Type: ``boolean``
+
+        - ``progress``: *(Optional)* If True, shows the progress bar during sampling.
+
+          - Type: ``boolean``
+
+        - ``backend_filename``: *(Optional)* Name of the HDF5 file where the emcee sampling state is saved for checkpointing.
+
+          - Type: ``string``
+          - Example:
+
+            .. code-block:: yaml
+
+               backend_filename: "mcmc_emcee_checkpoint.h5"
+
+        - ``start_from_backend``: *(Optional)* If True, start sampling from the state saved in ``backend_filename``.
+
+          - Type: ``boolean``
 
     - ``psf_iteration``: *(Optional)* Whether to perform iterative PSF fitting.
 

--- a/dolphin/ai/modeler.py
+++ b/dolphin/ai/modeler.py
@@ -123,7 +123,7 @@ class Modeler(AI):
                 "psf_symmetry": 4,
             }
         :type psf_iteration_settings: `dict` or `None`
-        :param sampler_name: sampler name, default is "emcee"
+        :param sampler_name: sampler name, default is "emcee". Supported options: "emcee", "Nautilus".
         :type sampler_name: `str`
         :param sampler_settings: sampler settings. If `None`, sampling will not be
             performed. If settings are provided, sampling will be performed.

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -33,8 +33,8 @@ class Output(Processor):
         self._fit_output = None
         self._kwargs_result = None
         self._model_settings = None
-        self._samples_mcmc = None
-        self._params_mcmc = None
+        self._samples = None
+        self._params_sampled = None
 
     @property
     def fit_output(self):
@@ -87,40 +87,40 @@ class Output(Processor):
             return self._model_settings
 
     @property
-    def samples_mcmc(self):
+    def samples(self):
         """The array of MCMC samples from the model run.
 
         :return: the array of MCMC samples
         :rtype: `numpy.ndarray` or `list`
         """
-        if self._samples_mcmc is None:
+        if self._samples is None:
             return []
         else:
-            return self._samples_mcmc
+            return self._samples
 
     @property
-    def params_mcmc(self):
+    def params_sampled(self):
         """The non-linear parameters sampled with MCMC.
 
         :return: the list of non-linear parameters sampled with MCMC
         :rtype: `list`
         """
-        if self._params_mcmc is None:
+        if self._params_sampled is None:
             return []
         else:
-            return self._params_mcmc
+            return self._params_sampled
 
     @property
-    def num_params_mcmc(self):
+    def num_params_sampled(self):
         """Number of sampled non-linear parameters in MCMC.
 
         :return: number of sampled non-linear parameters
         :rtype: `int`
         """
-        if self._params_mcmc is None:
+        if self._params_sampled is None:
             return 0
         else:
-            return len(self._params_mcmc)
+            return len(self._params_sampled)
 
     def swim(self, *args, **kwargs):
         """Override the `swim` method of the `Processor` class to make it not callable.
@@ -151,9 +151,9 @@ class Output(Processor):
         self._fit_output = output["fit_output"]
         self._multi_band_list_out = output["multi_band_list_out"]
 
-        if self.fit_output[-1][0] == "emcee":
-            self._samples_mcmc = self.fit_output[-1][1]
-            self._params_mcmc = self.fit_output[-1][2]
+        if self.fit_output[-1][0] in ["emcee", "Nautilus"]:
+            self._samples = self.fit_output[-1][1]
+            self._params_sampled = self.fit_output[-1][2]
 
         return output
 
@@ -476,14 +476,19 @@ class Output(Processor):
         """
         self.load_output(lens_name, model_id)
 
-        num_params = self.num_params_mcmc  # self.samples_mcmc.shape[1]
+        if self.fit_output[-1][0] == "Nautilus":
+            raise ValueError(
+                "Nautilus samples do not have walkers to reshape. Use `.samples_mcmc` directly."
+            )
+
+        num_params = self.num_params_sampled  # self.samples_mcmc.shape[1]
         num_walkers = walker_ratio * num_params
-        num_step = int(len(self.samples_mcmc) / num_walkers)
+        num_step = int(len(self.samples) / num_walkers)
 
         chain = np.empty((num_walkers, num_step, num_params))
 
         for i in np.arange(num_params):
-            samples = self.samples_mcmc[:, i].T
+            samples = self.samples[:, i].T
             chain[:, :, i] = samples.reshape((num_step, num_walkers)).T
         if burn_in != 0:
             chain = chain[:, burn_in:, :]
@@ -520,11 +525,19 @@ class Output(Processor):
         :return: `matplotlib.figure.Figure` instance with the plots
         :rtype: `matplotlib.figure.Figure`
         """
+        self.load_output(lens_name, model_id)
+        sampler_type = self.fit_output[-1][0]
+
+        if sampler_type == "Nautilus":
+            raise ValueError(
+                "Trace plotting is not supported for the Nautilus sampler."
+            )
+
         chain = self.get_reshaped_emcee_chain(
             lens_name, model_id, walker_ratio, burn_in=burn_in
         )
 
-        num_params = self.num_params_mcmc
+        num_params = self.num_params_sampled
         num_step = chain.shape[1]
 
         if len(parameters_to_plot) == 0:
@@ -532,11 +545,11 @@ class Output(Processor):
         else:
             parameter_list = []
             for i in parameters_to_plot:
-                if i in self.params_mcmc:
-                    parameter_list.append(self.params_mcmc.index(i))
+                if i in self.params_sampled:
+                    parameter_list.append(self.params_sampled.index(i))
                 else:
                     raise ValueError(
-                        f"Parameter '{i}' not found. Available parameters: {self.params_mcmc}"
+                        f"Parameter '{i}' not found. Available parameters: {self.params_sampled}"
                     )
 
         mean_pos = np.zeros((num_params, num_step))
@@ -565,7 +578,7 @@ class Output(Processor):
         for n, i in enumerate(parameter_list):
             if verbose:
                 print(
-                    self.params_mcmc[i],
+                    self.params_sampled[i],
                     "{:.4f} ± {:.4f}".format(
                         median_pos[i][last - 1],
                         (q84_pos[i][last - 1] - q16_pos[i][last - 1]) / 2,
@@ -582,7 +595,7 @@ class Output(Processor):
                 # ax[i].fill_between(np.arange(last), mean_pos[i][:last] \
                 # +std_pos[i][:last], mean_pos[i][:last]-std_pos[i][:last],
                 # alpha=0.4)
-                ax[n].set_ylabel(self.params_mcmc[i], fontsize=8)
+                ax[n].set_ylabel(self.params_sampled[i], fontsize=8)
                 ax[n].set_xlim(0, last)
             else:
                 ax.plot(median_pos[i][:last], c="g")
@@ -590,7 +603,7 @@ class Output(Processor):
                 ax.fill_between(
                     np.arange(last), q84_pos[i][:last], q16_pos[i][:last], alpha=0.4
                 )
-                ax.set_ylabel(self.params_mcmc[i], fontsize=8)
+                ax.set_ylabel(self.params_sampled[i], fontsize=8)
                 ax.set_xlim(0, last)
 
             medians.append(np.median(median_pos[i][burn_in:last]))

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -33,7 +33,7 @@ class Output(Processor):
         self._fit_output = None
         self._kwargs_result = None
         self._model_settings = None
-        self._samples = None
+        self._posterior_samples = None
         self._params_sampled = None
 
     @property
@@ -87,16 +87,16 @@ class Output(Processor):
             return self._model_settings
 
     @property
-    def samples(self):
+    def posterior_samples(self):
         """The array of posterior samples from the model run.
 
         :return: the array of posterior samples
         :rtype: `numpy.ndarray` or `list`
         """
-        if self._samples is None:
+        if self._posterior_samples is None:
             return []
         else:
-            return self._samples
+            return self._posterior_samples
 
     @property
     def params_sampled(self):
@@ -152,7 +152,7 @@ class Output(Processor):
         self._multi_band_list_out = output["multi_band_list_out"]
 
         if self.fit_output[-1][0] in ["emcee", "Nautilus"]:
-            self._samples = self.fit_output[-1][1]
+            self._posterior_samples = self.fit_output[-1][1]
             self._params_sampled = self.fit_output[-1][2]
 
         return output
@@ -483,12 +483,12 @@ class Output(Processor):
 
         num_params = self.num_params_sampled  # self.samples_mcmc.shape[1]
         num_walkers = walker_ratio * num_params
-        num_step = int(len(self.samples) / num_walkers)
+        num_step = int(len(self.posterior_samples) / num_walkers)
 
         chain = np.empty((num_walkers, num_step, num_params))
 
         for i in np.arange(num_params):
-            samples = self.samples[:, i].T
+            samples = self.posterior_samples[:, i].T
             chain[:, :, i] = samples.reshape((num_step, num_walkers)).T
         if burn_in != 0:
             chain = chain[:, burn_in:, :]

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -88,9 +88,9 @@ class Output(Processor):
 
     @property
     def samples(self):
-        """The array of MCMC samples from the model run.
+        """The array of posterior samples from the model run.
 
-        :return: the array of MCMC samples
+        :return: the array of posterior samples
         :rtype: `numpy.ndarray` or `list`
         """
         if self._samples is None:
@@ -100,9 +100,9 @@ class Output(Processor):
 
     @property
     def params_sampled(self):
-        """The non-linear parameters sampled with MCMC.
+        """The non-linear parameters sampled during the model run.
 
-        :return: the list of non-linear parameters sampled with MCMC
+        :return: the list of sampled non-linear parameters
         :rtype: `list`
         """
         if self._params_sampled is None:
@@ -112,7 +112,7 @@ class Output(Processor):
 
     @property
     def num_params_sampled(self):
-        """Number of sampled non-linear parameters in MCMC.
+        """Number of sampled non-linear parameters.
 
         :return: number of sampled non-linear parameters
         :rtype: `int`

--- a/dolphin/processor/files.py
+++ b/dolphin/processor/files.py
@@ -248,7 +248,7 @@ class FileSystem(object):
                     subgroup.create_dataset(
                         "param_list", data=np.array(single_output[2], dtype="S25")
                     )
-                elif single_output[0] == "emcee":
+                elif single_output[0] in ["emcee", "Nautilus"]:
                     subgroup.create_dataset(
                         "samples",
                         data=np.array(
@@ -258,12 +258,33 @@ class FileSystem(object):
                     subgroup.create_dataset(
                         "param_list", data=np.array(single_output[2], dtype="S25")
                     )
-                    subgroup.create_dataset(
-                        "log_likelihood",
-                        data=np.array(
-                            single_output[3],
-                        ),
-                    )
+                    if single_output[0] == "emcee":
+                        subgroup.create_dataset(
+                            "log_likelihood",
+                            data=np.array(
+                                single_output[3],
+                            ),
+                        )
+                    elif single_output[0] == "Nautilus":
+                        subgroup.create_dataset(
+                            "log_l", data=np.array(single_output[3])
+                        )
+                        subgroup.create_dataset(
+                            "log_z", data=np.array(single_output[4])
+                        )
+                        subgroup.create_dataset(
+                            "log_z_err", data=np.array(single_output[5])
+                        )
+                        results_group = subgroup.create_group("results_object")
+                        results_group.create_dataset(
+                            "points", data=np.array(single_output[6]["points"])
+                        )
+                        results_group.create_dataset(
+                            "log_w", data=np.array(single_output[6]["log_w"])
+                        )
+                        results_group.create_dataset(
+                            "log_l", data=np.array(single_output[6]["log_l"])
+                        )
                 else:
                     raise ValueError(
                         f"Fitting type {single_output[0]} not recognized for "
@@ -352,7 +373,7 @@ class FileSystem(object):
                             for s in group[index]["param_list"][:]
                         ]
                     )
-                elif fitting_step[0] == "emcee":
+                elif fitting_step[0] in ["emcee", "Nautilus"]:
                     fitting_step.append(group[index]["samples"][:])
                     fitting_step.append(
                         [
@@ -360,7 +381,18 @@ class FileSystem(object):
                             for s in group[index]["param_list"][:]
                         ]
                     )
-                    fitting_step.append(group[index]["log_likelihood"][:])
+                    if fitting_step[0] == "emcee":
+                        fitting_step.append(group[index]["log_likelihood"][:])
+                    elif fitting_step[0] == "Nautilus":
+                        fitting_step.append(group[index]["log_l"][()])
+                        fitting_step.append(group[index]["log_z"][()])
+                        fitting_step.append(group[index]["log_z_err"][()])
+                        results_object = {
+                            "points": group[index]["results_object"]["points"][()],
+                            "log_w": group[index]["results_object"]["log_w"][()],
+                            "log_l": group[index]["results_object"]["log_l"][()],
+                        }
+                        fitting_step.append(results_object)
 
                 fit_output.append(fitting_step)
 

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -227,7 +227,8 @@ class Recipe(object):
         return fitting_kwargs_list
 
     def get_sampling_sequence(self):
-        """Get the sampling sequence. Currently MCMC with emcee and nested sampling with Nautilus are supported.
+        """Get the sampling sequence. Currently MCMC with emcee and nested sampling with
+        Nautilus are supported.
 
         :return: a list containing the sampling sequence arguments
         :rtype: `list`

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -227,7 +227,7 @@ class Recipe(object):
         return fitting_kwargs_list
 
     def get_sampling_sequence(self):
-        """Get the sampling sequence. Currently only MCMC with emcee is supported.
+        """Get the sampling sequence. Currently MCMC with emcee and nested sampling with Nautilus are supported.
 
         :return: a list containing the sampling sequence arguments
         :rtype: `list`

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -242,7 +242,7 @@ class Recipe(object):
                 # "dyPolyChord",
                 # "MultiNest",
                 # "nested_sampling",
-                # "Nautilus",
+                "Nautilus",
             ]
             if self._config.settings["fitting"]["sampler"] not in supported_samplers:
                 raise ValueError(
@@ -253,7 +253,7 @@ class Recipe(object):
                 )
 
             sampling_kwargs = self._config.settings["fitting"]["sampler_settings"]
-            if self._config.settings["fitting"]["sampler"] in ["emcee"]:
+            if self._config.settings["fitting"]["sampler"] in ["emcee", "Nautilus"]:
                 if "threadCount" not in sampling_kwargs:
                     sampling_kwargs["threadCount"] = self._thread_count
 

--- a/test/test_analysis/test_output.py
+++ b/test/test_analysis/test_output.py
@@ -46,16 +46,16 @@ class TestOutput(object):
         with pytest.raises(ValueError):
             _ = self.output.model_settings
 
-        assert self.output.samples == []
+        assert self.output.posterior_samples == []
         assert self.output.params_sampled == []
         assert self.output.num_params_sampled == 0
 
         self.output._params_sampled = ["param1", "param2"]
         assert self.output.num_params_sampled == 2
 
-        self.output._samples = np.ones(10)
-        assert np.all(self.output.samples == np.ones(10))
-        self.output._samples = None
+        self.output._posterior_samples = np.ones(10)
+        assert np.all(self.output.posterior_samples == np.ones(10))
+        self.output._posterior_samples = None
 
         self.output._params_sampled = ["param1"]
         assert self.output.params_sampled == ["param1"]
@@ -193,7 +193,7 @@ class TestOutput(object):
         self.output.get_kwargs_from_args(
             "lens_system2",
             "example",
-            self.output.samples[0],
+            self.output.posterior_samples[0],
             linear_solve=True,
         )
 

--- a/test/test_analysis/test_output.py
+++ b/test/test_analysis/test_output.py
@@ -46,20 +46,20 @@ class TestOutput(object):
         with pytest.raises(ValueError):
             _ = self.output.model_settings
 
-        assert self.output.samples_mcmc == []
-        assert self.output.params_mcmc == []
-        assert self.output.num_params_mcmc == 0
+        assert self.output.samples == []
+        assert self.output.params_sampled == []
+        assert self.output.num_params_sampled == 0
 
-        self.output._params_mcmc = ["param1", "param2"]
-        assert self.output.num_params_mcmc == 2
+        self.output._params_sampled = ["param1", "param2"]
+        assert self.output.num_params_sampled == 2
 
-        self.output._samples_mcmc = np.ones(10)
-        assert np.all(self.output.samples_mcmc == np.ones(10))
-        self.output._samples_mcmc = None
+        self.output._samples = np.ones(10)
+        assert np.all(self.output.samples == np.ones(10))
+        self.output._samples = None
 
-        self.output._params_mcmc = ["param1"]
-        assert self.output.params_mcmc == ["param1"]
-        self.output._params_mcmc = None
+        self.output._params_sampled = ["param1"]
+        assert self.output.params_sampled == ["param1"]
+        self.output._params_sampled = None
 
     def test_load_output(self):
         """Test that outputs are saved and corresponding class variables are not None.
@@ -193,7 +193,7 @@ class TestOutput(object):
         self.output.get_kwargs_from_args(
             "lens_system2",
             "example",
-            self.output.samples_mcmc[0],
+            self.output.samples[0],
             linear_solve=True,
         )
 
@@ -280,3 +280,39 @@ class TestOutput(object):
                 band_index=0,
                 plot=False,
             )
+
+    def test_nautilus_exceptions(self):
+        """Test that Nautilus raises appropriate ValueErrors for MCMC-specific methods."""
+        save_dict = {
+            "settings": {"some": "settings"},
+            "kwargs_result": {"0": None},
+            "fit_output": [
+                [
+                    "Nautilus",
+                    np.ones((50, 2)),
+                    ["param1", "param2"],
+                    np.ones(50),
+                    np.ones(50),
+                    np.ones(50),
+                    {
+                        "points": np.ones((50, 2)),
+                        "log_w": np.ones(50),
+                        "log_l": np.ones(50),
+                    },
+                ]
+            ],
+            "multi_band_list_out": ["band1"],
+        }
+        self.processor.file_system.save_output("test_nautilus", "example", save_dict)
+
+        with pytest.raises(
+            ValueError,
+            match="Nautilus samples do not have walkers to reshape. Use `.samples_mcmc` directly.",
+        ):
+            self.output.get_reshaped_emcee_chain("test_nautilus", "example", 2)
+
+        with pytest.raises(
+            ValueError,
+            match="Trace plotting is not supported for the Nautilus sampler.",
+        ):
+            self.output.plot_mcmc_trace("test_nautilus", "example", 2)

--- a/test/test_analysis/test_output.py
+++ b/test/test_analysis/test_output.py
@@ -282,7 +282,8 @@ class TestOutput(object):
             )
 
     def test_nautilus_exceptions(self):
-        """Test that Nautilus raises appropriate ValueErrors for MCMC-specific methods."""
+        """Test that Nautilus raises appropriate ValueErrors for MCMC-specific
+        methods."""
         save_dict = {
             "settings": {"some": "settings"},
             "kwargs_result": {"0": None},

--- a/test/test_processor/test_files.py
+++ b/test/test_processor/test_files.py
@@ -145,6 +145,19 @@ class TestFileSystem(object):
                     ["{}".format(i) for i in range(4)],
                     np.ones(50),
                 ],
+                [
+                    "Nautilus",
+                    np.ones((50, 4)),
+                    np.array(["{}".format(i) for i in range(4)]),
+                    np.ones(50),
+                    np.ones(50),
+                    np.ones(50),
+                    {
+                        "points": np.ones((50, 4)),
+                        "log_w": np.ones(50),
+                        "log_l": np.ones(50),
+                    },
+                ],
             ],
             "multi_band_list_out": ["band1", "band2"],
         }
@@ -166,6 +179,17 @@ class TestFileSystem(object):
 
         for i in range(3):
             assert np.all(save_dict["fit_output"][1][i] == out["fit_output"][1][i])
+
+        out_nautilus = out["fit_output"][2]
+        save_nautilus = save_dict["fit_output"][2]
+        assert out_nautilus[0] == "Nautilus"
+        assert np.all(out_nautilus[1] == save_nautilus[1])
+        assert out_nautilus[2] == ["0", "1", "2", "3"]
+        assert np.all(out_nautilus[3] == save_nautilus[3])
+        assert np.all(out_nautilus[4] == save_nautilus[4])
+        assert np.all(out_nautilus[5] == save_nautilus[5])
+        for key in save_nautilus[6]:
+            assert np.all(out_nautilus[6][key] == save_nautilus[6][key])
 
         with pytest.raises(ValueError):
             save_dict["fit_output"].append(

--- a/test/test_processor/test_recipe.py
+++ b/test/test_processor/test_recipe.py
@@ -145,6 +145,14 @@ class TestRecipe(object):
             np.zeros(20),
         )
 
+        # test Nautilus
+        config_nautilus = deepcopy(self.config)
+        config_nautilus.settings["fitting"]["sampling"] = True
+        config_nautilus.settings["fitting"]["sampler"] = "Nautilus"
+        recipe_nautilus = Recipe(config_nautilus)
+        sequence_nautilus = recipe_nautilus.get_sampling_sequence()
+        assert sequence_nautilus[0][0] == "Nautilus"
+
     def test_get_galaxy_galaxy_recipe(self):
         """Test `get_galaxy_galaxy_recipe` method."""
         image = np.random.normal(size=(120, 120))


### PR DESCRIPTION
This pull request adds support for the Nautilus nested sampler alongside the existing emcee MCMC sampler, updates documentation and configuration options accordingly, and refactors variable and method names for clarity and generality in handling sampling results. It also ensures correct handling and storage of Nautilus-specific outputs and introduces tests for the new functionality and error handling.

**Sampler Support and Configuration:**

* Added support for the Nautilus nested sampler throughout the codebase, including documentation in `CONFIG_OPTIONS.rst`, configuration parsing, and recipe generation. Now both "emcee" and "Nautilus" can be selected as samplers, and relevant Nautilus options are documented. [[1]](diffhunk://#diff-cc5a203db5e6799157bb8eadd8afe3f8fdb5ea04c515f048f86da452bef584e3L451-R451) [[2]](diffhunk://#diff-cc5a203db5e6799157bb8eadd8afe3f8fdb5ea04c515f048f86da452bef584e3L460-R521) [[3]](diffhunk://#diff-31d164837067bdc0d3e84dcd35813de5711dc28f8cbbd35631dc72c2fa4cb458L230-R231) [[4]](diffhunk://#diff-31d164837067bdc0d3e84dcd35813de5711dc28f8cbbd35631dc72c2fa4cb458L245-R246) [[5]](diffhunk://#diff-bda95bdca93750011e87413785de417cb38dc7220447cec7b745a0738a9da67dL126-R126)
* Updated configuration and documentation to list and describe recommended Nautilus options (e.g., `n_live`, `n_eff`, `verbose`, `filepath`, etc.), and to clarify sampler selection and settings. [[1]](diffhunk://#diff-cc5a203db5e6799157bb8eadd8afe3f8fdb5ea04c515f048f86da452bef584e3L460-R521) [[2]](diffhunk://#diff-cc5a203db5e6799157bb8eadd8afe3f8fdb5ea04c515f048f86da452bef584e3R553-R600)

**Refactoring for Generality:**

* Refactored variable and property names in `dolphin/analysis/output.py` from MCMC-specific (`samples_mcmc`, `params_mcmc`, etc.) to generalized forms (`posterior_samples`, `params_sampled`, etc.) to support both emcee and Nautilus outputs. [[1]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L36-R37) [[2]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L90-R123) [[3]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L154-R156)
* Updated all usages and tests to use the new generalized names, ensuring consistency and clarity. [[1]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L479-R491) [[2]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575R528-R552) [[3]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L568-R581) [[4]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L585-R606) [[5]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3L49-R62) [[6]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3L196-R196)

**Output Handling and Storage:**

* Modified output saving and loading logic to handle Nautilus-specific outputs (e.g., `log_l`, `log_z`, `log_z_err`, and results object fields) in HDF5 files, ensuring all relevant data is correctly persisted and restored. [[1]](diffhunk://#diff-5c0fa9af03879ac54920295a5fda1690c5edcb40774f9d3274ee51543b9b1f32L251-R251) [[2]](diffhunk://#diff-5c0fa9af03879ac54920295a5fda1690c5edcb40774f9d3274ee51543b9b1f32R261-R287) [[3]](diffhunk://#diff-5c0fa9af03879ac54920295a5fda1690c5edcb40774f9d3274ee51543b9b1f32L355-R395)

**Error Handling and Method Restrictions:**

* Added logic to raise clear exceptions when attempting to use emcee-specific methods (e.g., walker chain reshaping, trace plotting) with Nautilus outputs, since these are not applicable to nested sampling. [[1]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L479-R491) [[2]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575R528-R552) [[3]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3R283-R319)

**Testing:**

* Added and updated tests to cover the new Nautilus functionality, including verifying correct exception raising for unsupported operations and ensuring the new naming conventions are used throughout. [[1]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3L49-R62) [[2]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3L196-R196) [[3]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3R283-R319)