### PR TITLE
Add UNIFORM lens light model

### DIFF
--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -320,9 +320,10 @@ class ModelConfig(Config):
 
         if num_lens_light_profile_central > 1:
             for n in range(1, num_lens_light_profile_central * self.number_of_bands):
-                joint_lens_light_with_lens_light.append(
-                    [0, n, ["center_x", "center_y"]]
-                )
+                if lens_light_model_list[n] != "UNIFORM":
+                    joint_lens_light_with_lens_light.append(
+                        [0, n, ["center_x", "center_y"]]
+                    )
 
         # Join profile-specific parameters in multiband fitting
         if self.number_of_bands > 1:
@@ -1223,6 +1224,29 @@ class ModelConfig(Config):
                     _lower.update({"e1": -0.5, "e2": -0.5})
                     _upper.update({"e1": 0.5, "e2": 0.5})
 
+                fixed.append(_fixed)
+                init.append(_init)
+                sigma.append(_sigma)
+                lower.append(_lower)
+                upper.append(_upper)
+            elif model == "UNIFORM":
+                _fixed = {}
+    
+                _init = {
+                    "amp": 0.0,
+                }
+    
+                _sigma = {
+                    "amp": 1.0,
+                }
+    
+                _lower = {
+                    "amp": -100.0,
+                }
+    
+                _upper = {
+                    "amp": 100.0,
+                }
                 fixed.append(_fixed)
                 init.append(_init)
                 sigma.append(_sigma)

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1231,19 +1231,19 @@ class ModelConfig(Config):
                 upper.append(_upper)
             elif model == "UNIFORM":
                 _fixed = {}
-    
+
                 _init = {
                     "amp": 0.0,
                 }
-    
+
                 _sigma = {
                     "amp": 1.0,
                 }
-    
+
                 _lower = {
                     "amp": -100.0,
                 }
-    
+
                 _upper = {
                     "amp": 100.0,
                 }

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -730,19 +730,11 @@ class TestModelConfig(object):
         config2.settings["lens_light_option"]["fix"] = {}
         params = config2.get_lens_light_model_params()
 
-        assert params[0] == [{
-            "amp": 0.0
-        }]
-        assert params[1] == [{
-            "amp": 1.0
-        }]
+        assert params[0] == [{"amp": 0.0}]
+        assert params[1] == [{"amp": 1.0}]
         assert params[2] == [{}]
-        assert params[3] == [{
-            "amp": -100.0
-        }]
-        assert params[4] == [{
-            "amp": 100.0
-        }]
+        assert params[3] == [{"amp": -100.0}]
+        assert params[4] == [{"amp": 100.0}]
 
     def test_get_source_light_model_params(self):
         """Test `get_source_light_model_params` method.

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -725,6 +725,25 @@ class TestModelConfig(object):
             "n_sersic": 4.0,
         }
 
+        config2 = deepcopy(self.config_1)
+        config2.settings["model"]["lens_light"] = ["UNIFORM"]
+        config2.settings["lens_light_option"]["fix"] = {}
+        params = config2.get_lens_light_model_params()
+
+        assert params[0] == [{
+            "amp": 0.0
+        }]
+        assert params[1] == [{
+            "amp": 1.0
+        }]
+        assert params[2] == [{}]
+        assert params[3] == [{
+            "amp": -100.0
+        }]
+        assert params[4] == [{
+            "amp": 100.0
+        }]
+
     def test_get_source_light_model_params(self):
         """Test `get_source_light_model_params` method.
 


### PR DESCRIPTION
This pull request implements the UNIFORM lens light model. In ``Lenstronomy``, UNIFORM is a profile that compensates for inaccurate background subtraction.