### PR TITLE
Enhancement/refactoring

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -317,7 +317,7 @@ Point Source Options
            gaussian_prior:
              0: [[ra_image, 0.1, 0.05]]
 
-    - ``time_delays_measured``: Relative time delays (in days) with respect to the first image of the point source.
+    - ``time_delays_measured``: Relative time delays (in days) with respect to the first point-source image. If this is provided, ``time_delays_covariance`` must also be provided to compute the time-delay likelihood, which is then added to the combined likelihood.
 
       - Type: ``list of floats```
       - Example:

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -326,7 +326,7 @@ Point Source Options
 
           time_delays_measured: [3., 2., 1.]
 
-    - ``time_delays_covariance``: Full covariance matrix that describes the uncertainties.
+    - ``time_delays_covariance``: Full covariance matrix of the provided time delay measurements.
   
       - Type: ``list of list of floats``
       - Example:

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -326,14 +326,14 @@ Point Source Options
 
           time_delays_measured: [3., 2., 1.]
 
-    - ``time_delays_uncertainties``: Full covariance matrix that describes the uncertainties.
+    - ``time_delays_covariance``: Full covariance matrix that describes the uncertainties.
   
       - Type: ``list of list of floats``
       - Example:
 
         .. code-block:: yaml
 
-          time_delays_uncertainties: [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]
+          time_delays_covariance: [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]
 
 Special Options
 ---------------

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -530,7 +530,7 @@ class ModelConfig(Config):
         if "point_source_option" in self.settings:
             if (
                 "time_delays_measured" in self.settings["point_source_option"]
-                and "time_delays_uncertainties" in self.settings["point_source_option"]
+                and "time_delays_covariance" in self.settings["point_source_option"]
             ):
                 kwargs_likelihood.update({"time_delay_likelihood": True})
 

--- a/dolphin/processor/core.py
+++ b/dolphin/processor/core.py
@@ -186,10 +186,8 @@ class Processor(object):
                     "time_delays_measured": np.array(
                         config.settings["point_source_option"]["time_delays_measured"]
                     ),
-                    "time_delays_uncertainties": np.array(
-                        config.settings["point_source_option"][
-                            "time_delays_uncertainties"
-                        ]
+                    "time_delays_covariance": np.array(
+                        config.settings["point_source_option"]["time_delays_covariance"]
                     ),
                 }
             )

--- a/dolphin/processor/core.py
+++ b/dolphin/processor/core.py
@@ -180,7 +180,11 @@ class Processor(object):
         model = config.settings.get("model", {})
         point_source_option = config.settings.get("point_source_option", {})
 
-        if "point_source" in model and "time_delays_measured" in point_source_option:
+        if (
+            "point_source" in model
+            and "time_delays_measured" in point_source_option
+            and "time_delays_covariance" in point_source_option
+        ):
             kwargs_data_joint.update(
                 {
                     "time_delays_measured": np.array(

--- a/io_directory_example/settings/lens_system5_config.yaml
+++ b/io_directory_example/settings/lens_system5_config.yaml
@@ -22,7 +22,7 @@ point_source_option:
   dec_init: [0., 1., 0., -1.]
   bound: 0.1
   time_delays_measured: [1., 1., 1.]
-  time_delays_uncertainties: [[0.5, 0., 0.], [0., 0.5, 0.], [0., 0., 0.5]]
+  time_delays_covariance: [[0.5, 0., 0.], [0., 0.5, 0.], [0., 0., 0.5]]
 
 fitting:
   psf_iteration: true

--- a/test/test_processor/test_core.py
+++ b/test/test_processor/test_core.py
@@ -44,7 +44,7 @@ class TestProcessor(object):
             kwargs_data_joint["time_delays_measured"], [1.0, 1.0, 1.0]
         )
         npt.assert_array_equal(
-            kwargs_data_joint["time_delays_uncertainties"],
+            kwargs_data_joint["time_delays_covariance"],
             [[0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 0.5]],
         )
 


### PR DESCRIPTION
This pull request updates the terminology and handling of time delay uncertainties for point sources, standardizing on the term `time_delays_covariance` instead of `time_delays_uncertainties` throughout the codebase, documentation, configuration, and tests. It also ensures that the code checks for the presence of both `time_delays_measured` and `time_delays_covariance` before including related likelihoods and data.