### PR TITLE
Correct for missing time_delay_likelihood options

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -378,6 +378,24 @@ Special Options
         
            delta_image_upper: 0.004
 
+    - ``H0``: Fiducial Hubble constant in km/s/Mpc.
+  
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          H0: 70.0
+
+    - ``Om0``: Fiducial baryonic matter density.
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          Om0: 0.3
+
 Guess Parameters
 ----------------
 

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -387,7 +387,7 @@ Special Options
 
           H0: 70.0
 
-    - ``Om0``: Fiducial baryonic matter density.
+    - ``Om0``: Fiducial matter energy density.
 
       - Type: ``float``
       - Example:

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1030,9 +1030,8 @@ class ModelConfig(Config):
         if "point_source_option" in self.settings:
             if (
                 "time_delays_measured" in self.settings["point_source_option"]
-                 and "time_delays_covariance"
-                in self.settings["point_source_option"]
-             ):
+                and "time_delays_covariance" in self.settings["point_source_option"]
+            ):
                 special_list.append("time_delay_likelihood")
 
         return special_list
@@ -1612,28 +1611,12 @@ class ModelConfig(Config):
                 )
                 D_dt_fiducial = float(lens_cosmo_for_Ddt.ddt)
 
-                init.update(
-                    {
-                        "D_dt": D_dt_fiducial
-                    }
-                )
-                sigma.update(
-                    {
-                        "D_dt": 0.25 * D_dt_fiducial
-                    }
-                )
-                lower.update(
-                    {
-                        "D_dt": 0.5 * D_dt_fiducial
-                    }
-                )
-                upper.update(
-                    {
-                        "D_dt": 2.0 * D_dt_fiducial
-                    }
-                )
+                init.update({"D_dt": D_dt_fiducial})
+                sigma.update({"D_dt": 0.25 * D_dt_fiducial})
+                lower.update({"D_dt": 0.5 * D_dt_fiducial})
+                upper.update({"D_dt": 2.0 * D_dt_fiducial})
                 fixed.update({})
-    
+
         params = [init, sigma, fixed, lower, upper]
         return params
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -12,6 +12,10 @@ import lenstronomy.Util.util as util
 import lenstronomy.Util.mask_util as mask_util
 import os
 
+from astropy import units as u
+from astropy.cosmology import FlatLambdaCDM
+from lenstronomy.Cosmo.lens_cosmo import LensCosmo
+
 from .data import ImageData
 from .files import FileSystem
 
@@ -291,6 +295,8 @@ class ModelConfig(Config):
             for i, model in enumerate(special_list):
                 if model == "astrometric_uncertainty":
                     kwargs_constraints.update({"point_source_offset": True})
+                if model == "time_delay_likelihood":
+                    kwargs_constraints.update({"Ddt_sampling": True})
 
         if (
             "kwargs_constraints" in self.settings
@@ -1012,22 +1018,24 @@ class ModelConfig(Config):
             return []
 
     def get_special_list(self):
-        """Return `special_list`.
-
-        :return: list of special parameters
-        :rtype: `list` of `str`
-        """
         special_list = []
 
         if "special" in self.settings["model"]:
-            if "astrometric_uncertainty" in self.settings["model"]["special"]:
-                special_list.append("astrometric_uncertainty")
-                return special_list
-            elif self.settings["model"]["special"] != "astrometric_uncertainty":
-                special = self.settings["model"]["special"]
-                raise ValueError(f"{special} not supported")
-        else:
-            return []
+            for model in self.settings["model"]["special"]:
+                if model == "astrometric_uncertainty":
+                    special_list.append("astrometric_uncertainty")
+                else:
+                    raise ValueError(f"{model} not supported")
+
+        if "point_source_option" in self.settings:
+            if (
+                "time_delays_measured" in self.settings["point_source_option"]
+                 and "time_delays_covariance"
+                in self.settings["point_source_option"]
+             ):
+                special_list.append("time_delay_likelihood")
+
+        return special_list
 
     def get_index_list(self, light_type="lens_light"):
         """Create a list of indices for the different light profiles (for multiple
@@ -1593,7 +1601,39 @@ class ModelConfig(Config):
                 )
 
                 fixed.update({})
+            elif model == "time_delay_likelihood":
+                H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
+                Om0 = self.settings["special_option"]["Om0"]
+                cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
+                lens_cosmo_for_Ddt = LensCosmo(
+                    z_lens=self.settings["kwargs_model"]["z_lens"],
+                    z_source=self.settings["kwargs_model"]["z_source"],
+                    cosmo=cosmo,
+                )
+                D_dt_fiducial = float(lens_cosmo_for_Ddt.ddt)
 
+                init.update(
+                    {
+                        "D_dt": D_dt_fiducial
+                    }
+                )
+                sigma.update(
+                    {
+                        "D_dt": 0.25 * D_dt_fiducial
+                    }
+                )
+                lower.update(
+                    {
+                        "D_dt": 0.5 * D_dt_fiducial
+                    }
+                )
+                upper.update(
+                    {
+                        "D_dt": 2.0 * D_dt_fiducial
+                    }
+                )
+                fixed.update({})
+    
         params = [init, sigma, fixed, lower, upper]
         return params
 
@@ -1645,6 +1685,10 @@ class ModelConfig(Config):
             "special": self.get_special_params(),
             # 'cosmography': []
         }
+
+        special_list = self.get_special_list()
+        if "time_delay_likelihood" in special_list:
+            kwargs_params.update({"Ddt_sampling": True})
 
         return kwargs_params
 

--- a/dolphin/processor/core.py
+++ b/dolphin/processor/core.py
@@ -190,7 +190,7 @@ class Processor(object):
                     "time_delays_measured": np.array(
                         config.settings["point_source_option"]["time_delays_measured"]
                     ),
-                    "time_delays_covariance": np.array(
+                    "time_delays_uncertainties": np.array(
                         config.settings["point_source_option"]["time_delays_covariance"]
                     ),
                 }

--- a/io_directory_example/settings/lens_system5_config.yaml
+++ b/io_directory_example/settings/lens_system5_config.yaml
@@ -24,6 +24,10 @@ point_source_option:
   time_delays_measured: [1., 1., 1.]
   time_delays_covariance: [[0.5, 0., 0.], [0., 0.5, 0.], [0., 0., 0.5]]
 
+special_option:
+  H0: 70.0
+  Om0: 0.3
+
 fitting:
   psf_iteration: true
   psf_iteration_settings:
@@ -48,3 +52,7 @@ fitting:
 
 numeric_option:
   supersampling_factor: [2]
+
+kwargs_model:
+  z_lens: 0.5
+  z_source: 1.0

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -627,7 +627,10 @@ class TestModelConfig(object):
         # if specified in config file
         config = deepcopy(self.config_5)
         config.settings["model"]["special"] = ["astrometric_uncertainty"]
-        assert config.get_special_list() == ["astrometric_uncertainty", "time_delay_likelihood"]
+        assert config.get_special_list() == [
+            "astrometric_uncertainty",
+            "time_delay_likelihood",
+        ]
 
         # Test 2: ensure special list is empty if not
         # specified in the config file
@@ -755,7 +758,7 @@ class TestModelConfig(object):
             "delta_image_lower": -0.004,
             "delta_image_upper": 0.004,
             "H0": 70,
-            "Om0": 0.3
+            "Om0": 0.3,
         }
 
         params = config.get_special_params()

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -229,6 +229,7 @@ class TestModelConfig(object):
 
         kwargs_constraints5 = config_5.get_kwargs_constraints()
         assert kwargs_constraints5["point_source_offset"]
+        assert kwargs_constraints5["Ddt_sampling"]
 
     def test_get_kwargs_likelihood(self):
         """Test `get_kwargs_likelihood` method."""
@@ -499,6 +500,9 @@ class TestModelConfig(object):
 
             assert len(kwargs_params[key]) == 5
 
+        kwargs_params = self.config_5.get_kwargs_params()
+        assert kwargs_params["Ddt_sampling"]
+
     def test_get_kwargs_numerics(self):
         """Test `get_kwargs_numerics` method."""
         test_numerics = [
@@ -623,7 +627,7 @@ class TestModelConfig(object):
         # if specified in config file
         config = deepcopy(self.config_5)
         config.settings["model"]["special"] = ["astrometric_uncertainty"]
-        assert config.get_special_list() == ["astrometric_uncertainty"]
+        assert config.get_special_list() == ["astrometric_uncertainty", "time_delay_likelihood"]
 
         # Test 2: ensure special list is empty if not
         # specified in the config file
@@ -750,6 +754,8 @@ class TestModelConfig(object):
             "delta_y_image": [0.004, 0.004, 0.004, 0.004],
             "delta_image_lower": -0.004,
             "delta_image_upper": 0.004,
+            "H0": 70,
+            "Om0": 0.3
         }
 
         params = config.get_special_params()
@@ -773,6 +779,11 @@ class TestModelConfig(object):
 
         assert np.all(lower["delta_y_image"] == -0.004)
         assert np.all(upper["delta_y_image"] == 0.004)
+
+        assert "D_dt" in init
+        assert "D_dt" in sigma
+        assert "D_dt" in lower
+        assert "D_dt" in upper
 
         assert fixed == {}
 

--- a/test/test_processor/test_core.py
+++ b/test/test_processor/test_core.py
@@ -44,7 +44,7 @@ class TestProcessor(object):
             kwargs_data_joint["time_delays_measured"], [1.0, 1.0, 1.0]
         )
         npt.assert_array_equal(
-            kwargs_data_joint["time_delays_covariance"],
+            kwargs_data_joint["time_delays_uncertainties"],
             [[0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 0.5]],
         )
 


### PR DESCRIPTION
My previous PR implementing ``time_delay_likelihood`` utilized an outdated version of Lenstronomy. In this PR, I correct for my mistakes by adding:

1) Logic in ``get_special_list`` to detect when time_delay_likelihood will be used
2) Input the proper ``D_dt`` parameters to the ``special`` parameter set
3) Automatically add ``Ddt_sampling: True`` to ``kwargs_constraints`` and ``kwargs_params`` when time_delay_likelihood is in use.
4) Revert the naming of ``time_delay_covariance`` in ``core.py`` back to ``time_delay_uncertainties``, as this is the string that Lenstronomy expects. We should still keep the call in the config file as ``time_delay_covariance``, as this naming is describing how it actually functions.
5) Added corresponding test functions.
6) Add ``H0`` and ``Om0`` as special options for models that utilize a fiducial cosmology (such as when using time_delay_likelihood).