### PR TITLE
Add multi_plane support

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -378,7 +378,16 @@ Special Options
         
            delta_image_upper: 0.004
 
-    - ``H0``: Fiducial Hubble constant in km/s/Mpc.
+    - ``cosmology``: *(Optional)* Astropy cosmology model to use for time-delay computations. Supported models: ``FlatLambdaCDM`` (default), ``LambdaCDM``, ``FlatwCDM``, ``wCDM``, ``Flatw0waCDM``, ``w0waCDM``.
+
+      - Type: ``string``
+      - Example:
+
+        .. code-block:: yaml
+
+           cosmology: "FlatLambdaCDM"
+
+    - ``H0``: Fiducial Hubble constant in km/s/Mpc (required for all cosmologies).
   
       - Type: ``float``
       - Example:
@@ -387,7 +396,7 @@ Special Options
 
           H0: 70.0
 
-    - ``Om0``: Fiducial matter energy density.
+    - ``Om0``: Fiducial matter energy density at z=0 (required for all cosmologies).
 
       - Type: ``float``
       - Example:
@@ -395,6 +404,42 @@ Special Options
         .. code-block:: yaml
 
           Om0: 0.3
+
+    - ``Ode0``: *(Optional)* Fiducial dark energy density at z=0 (required for non-flat cosmologies like ``LambdaCDM``, ``wCDM``, ``w0waCDM``).
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          Ode0: 0.7
+
+    - ``w0``: *(Optional)* Dark energy equation of state parameter at z=0 (used in ``wCDM``, ``FlatwCDM``, ``w0waCDM``, ``Flatw0waCDM``).
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          w0: -1.0
+
+    - ``wa``: *(Optional)* Dark energy equation of state parameter derivative (used in ``w0waCDM``, ``Flatw0waCDM``).
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          wa: 0.0
+
+    - ``Tcmb0``: *(Optional)* Temperature of the CMB at z=0 in Kelvin.
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          Tcmb0: 2.725
 
 Guess Parameters
 ----------------

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -379,6 +379,7 @@ Special Options
            delta_image_upper: 0.004
 
     - ``cosmology``: *(Optional)* Astropy cosmology model to use for time-delay computations. Supported models: ``FlatLambdaCDM`` (default), ``LambdaCDM``, ``FlatwCDM``, ``wCDM``, ``Flatw0waCDM``, ``w0waCDM``.
+    - ``cosmology``: *(Optional)* Astropy cosmology model to use for time-delay computations. Supported models: ``FlatLambdaCDM`` (default), ``LambdaCDM``, ``FlatwCDM``, ``wCDM``, ``Flatw0waCDM``, ``w0waCDM``, ``w0wzCDM``, ``Flatw0wzCDM``, ``wpwaCDM``, ``FlatwpwaCDM``.
 
       - Type: ``string``
       - Example:
@@ -406,6 +407,7 @@ Special Options
           Om0: 0.3
 
     - ``Ode0``: *(Optional)* Fiducial dark energy density at z=0 (required for non-flat cosmologies like ``LambdaCDM``, ``wCDM``, ``w0waCDM``).
+    - ``Ode0``: *(Optional)* Fiducial dark energy density at z=0 (required for non-flat cosmologies like ``LambdaCDM``, ``wCDM``, ``w0waCDM``, ``w0wzCDM``, ``wpwaCDM``).
 
       - Type: ``float``
       - Example:
@@ -415,6 +417,7 @@ Special Options
           Ode0: 0.7
 
     - ``w0``: *(Optional)* Dark energy equation of state parameter at z=0 (used in ``wCDM``, ``FlatwCDM``, ``w0waCDM``, ``Flatw0waCDM``).
+    - ``w0``: *(Optional)* Dark energy equation of state parameter at z=0 (used in ``wCDM``, ``FlatwCDM``, ``w0waCDM``, ``Flatw0waCDM``, ``w0wzCDM``, ``Flatw0wzCDM``).
 
       - Type: ``float``
       - Example:
@@ -424,6 +427,7 @@ Special Options
           w0: -1.0
 
     - ``wa``: *(Optional)* Dark energy equation of state parameter derivative (used in ``w0waCDM``, ``Flatw0waCDM``).
+    - ``wa``: *(Optional)* Dark energy equation of state parameter derivative (used in ``w0waCDM``, ``Flatw0waCDM``, ``wpwaCDM``, ``FlatwpwaCDM``).
 
       - Type: ``float``
       - Example:
@@ -431,6 +435,33 @@ Special Options
         .. code-block:: yaml
 
           wa: 0.0
+
+    - ``wz``: *(Optional)* Dark energy equation of state parameter derivative with respect to redshift (used in ``w0wzCDM``, ``Flatw0wzCDM``).
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          wz: 0.1
+
+    - ``wp``: *(Optional)* Dark energy equation of state parameter at the pivot redshift (used in ``wpwaCDM``, ``FlatwpwaCDM``).
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          wp: -1.0
+
+    - ``zp``: *(Optional)* Pivot redshift (used in ``wpwaCDM``, ``FlatwpwaCDM``).
+
+      - Type: ``float``
+      - Example:
+
+        .. code-block:: yaml
+
+          zp: 0.5
 
     - ``Tcmb0``: *(Optional)* Temperature of the CMB at z=0 in Kelvin.
 

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -378,7 +378,6 @@ Special Options
         
            delta_image_upper: 0.004
 
-    - ``cosmology``: *(Optional)* Astropy cosmology model to use for time-delay computations. Supported models: ``FlatLambdaCDM`` (default), ``LambdaCDM``, ``FlatwCDM``, ``wCDM``, ``Flatw0waCDM``, ``w0waCDM``.
     - ``cosmology``: *(Optional)* Astropy cosmology model to use for time-delay computations. Supported models: ``FlatLambdaCDM`` (default), ``LambdaCDM``, ``FlatwCDM``, ``wCDM``, ``Flatw0waCDM``, ``w0waCDM``, ``w0wzCDM``, ``Flatw0wzCDM``, ``wpwaCDM``, ``FlatwpwaCDM``.
 
       - Type: ``string``
@@ -406,7 +405,6 @@ Special Options
 
           Om0: 0.3
 
-    - ``Ode0``: *(Optional)* Fiducial dark energy density at z=0 (required for non-flat cosmologies like ``LambdaCDM``, ``wCDM``, ``w0waCDM``).
     - ``Ode0``: *(Optional)* Fiducial dark energy density at z=0 (required for non-flat cosmologies like ``LambdaCDM``, ``wCDM``, ``w0waCDM``, ``w0wzCDM``, ``wpwaCDM``).
 
       - Type: ``float``
@@ -416,7 +414,6 @@ Special Options
 
           Ode0: 0.7
 
-    - ``w0``: *(Optional)* Dark energy equation of state parameter at z=0 (used in ``wCDM``, ``FlatwCDM``, ``w0waCDM``, ``Flatw0waCDM``).
     - ``w0``: *(Optional)* Dark energy equation of state parameter at z=0 (used in ``wCDM``, ``FlatwCDM``, ``w0waCDM``, ``Flatw0waCDM``, ``w0wzCDM``, ``Flatw0wzCDM``).
 
       - Type: ``float``
@@ -426,7 +423,6 @@ Special Options
 
           w0: -1.0
 
-    - ``wa``: *(Optional)* Dark energy equation of state parameter derivative (used in ``w0waCDM``, ``Flatw0waCDM``).
     - ``wa``: *(Optional)* Dark energy equation of state parameter derivative (used in ``w0waCDM``, ``Flatw0waCDM``, ``wpwaCDM``, ``FlatwpwaCDM``).
 
       - Type: ``float``

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1789,7 +1789,7 @@ _LOADER_KEYS = {
 }
 
 
-def _build_cosmology(special_option: dict):
+def _build_cosmology(special_option):
     """
     Build and return an astropy cosmology object from *special_option*.
 
@@ -1797,11 +1797,11 @@ def _build_cosmology(special_option: dict):
     All other keys are forwarded as constructor arguments, with unit
     conversions applied where required.
 
-    Raises
-    ------
-    ValueError
-        If the requested cosmology is not in the registry, or a required
-        parameter is missing.
+    :param special_option: dictionary of options for special likelihoods, including cosmology parameters
+    :type special_option: `dict`
+    :return: an instance of the selected astropy cosmology class
+    :rtype: `astropy.cosmology.Cosmology`
+    :raises ValueError: if the specified cosmology is not supported or if required parameters are missing
     """
     cosmo_name = special_option.get("cosmology", "FlatLambdaCDM")
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -246,11 +246,16 @@ class ModelConfig(Config):
         ):
             for key, value in self.settings["kwargs_model"].items():
                 kwargs_model[key] = value
-                if key == "multi_plane" and True:
-                    H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
-                    Om0 = self.settings["special_option"]["Om0"]
-                    cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
-                    kwargs_model.update({"cosmo": cosmo})
+
+        if "special_option" in self.settings:
+            if (
+                "H0" in self.settings["special_option"]
+                and "Om0" in self.settings["special_option"]
+            ):
+                H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
+                Om0 = self.settings["special_option"]["Om0"]
+                cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
+                kwargs_model.update({"cosmo": cosmo})
 
         return kwargs_model
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -13,7 +13,14 @@ import lenstronomy.Util.mask_util as mask_util
 import os
 
 from astropy import units as u
-from astropy.cosmology import FlatLambdaCDM
+from astropy.cosmology import (
+    FlatLambdaCDM,
+    LambdaCDM,
+    FlatwCDM,
+    wCDM,
+    Flatw0waCDM,
+    w0waCDM,
+)
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 
 from .data import ImageData
@@ -248,16 +255,34 @@ class ModelConfig(Config):
                 kwargs_model[key] = value
 
         if "special_option" in self.settings:
-            if (
-                "H0" in self.settings["special_option"]
-                and "Om0" in self.settings["special_option"]
-            ):
-                H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
-                Om0 = self.settings["special_option"]["Om0"]
-                cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
-                kwargs_model.update({"cosmo": cosmo})
+            special = self.settings["special_option"]
+            cosmo = self._get_cosmology_instance(special)
+            kwargs_model.update({"cosmo": cosmo})
 
         return kwargs_model
+
+    @staticmethod
+    def _get_cosmology_instance(special):
+        """
+        Build and return a cosmology instance from the "special_option" settings.
+
+        This is a helper method for backward compatibility with older config files that
+        specified cosmology settings in "special_option" without the "cosmology" key. It
+        checks for the presence of cosmology-related keys and attempts to build a cosmology
+        instance if they are found. If the "cosmology" key is present, it uses the new
+        registry-based approach. If not, it falls back to the old method of checking for
+        specific cosmology parameters.
+        :param special: the "special_option" dictionary from settings
+        :type special: `dict`
+        :return: a cosmology instance
+        :rtype: `astropy.cosmology.Cosmology` or `None`
+        """
+        cosmo_keys = set(special) - _LOADER_KEYS
+        cosmo = None
+        if cosmo_keys:
+            cosmo = _build_cosmology(special)
+
+        return cosmo
 
     def get_kwargs_constraints(self, use_jax=False):
         """Create `kwargs_constraints` dictionary for lenstronomy.
@@ -1611,9 +1636,8 @@ class ModelConfig(Config):
 
                 fixed.update({})
             elif model == "time_delay_likelihood":
-                H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
-                Om0 = self.settings["special_option"]["Om0"]
-                cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
+                special = self.settings["special_option"]
+                cosmo = self._get_cosmology_instance(special)
                 lens_cosmo_for_Ddt = LensCosmo(
                     z_lens=self.settings["kwargs_model"]["z_lens"],
                     z_source=self.settings["kwargs_model"]["z_source"],
@@ -1697,3 +1721,116 @@ class ModelConfig(Config):
             return 1
         else:
             return self.settings["psf_supersampled_factor"]
+
+
+# Registry of supported cosmology classes and their unitful parameters.
+# Keys are the string names a user puts in settings["special_option"]["cosmology"].
+COSMOLOGY_REGISTRY = {
+    "FlatLambdaCDM": {
+        "class": FlatLambdaCDM,
+        # Parameters that require units before being passed to the constructor.
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        # Required parameters (must be present in settings).
+        "required": {"H0", "Om0"},
+    },
+    "LambdaCDM": {
+        "class": LambdaCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0", "Ode0"},
+    },
+    "FlatwCDM": {
+        "class": FlatwCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0"},
+    },
+    "wCDM": {
+        "class": wCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0", "Ode0"},
+    },
+    "Flatw0waCDM": {
+        "class": Flatw0waCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0"},
+    },
+    "w0waCDM": {
+        "class": w0waCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0", "Ode0"},
+    },
+}
+
+# Parameters that are intentionally NOT forwarded to the cosmology constructor
+# (they are meta-keys used only by this loader).
+_LOADER_KEYS = {
+    "cosmology",
+    "delta_x_image",
+    "delta_y_image",
+    "delta_image_lower",
+    "delta_image_upper",
+}
+
+
+def _build_cosmology(special_option: dict):
+    """
+    Build and return an astropy cosmology object from *special_option*.
+
+    The ``cosmology`` key selects the model (default: ``"FlatLambdaCDM"``).
+    All other keys are forwarded as constructor arguments, with unit
+    conversions applied where required.
+
+    Raises
+    ------
+    ValueError
+        If the requested cosmology is not in the registry, or a required
+        parameter is missing.
+    """
+    cosmo_name = special_option.get("cosmology", "FlatLambdaCDM")
+
+    if cosmo_name not in COSMOLOGY_REGISTRY:
+        supported = ", ".join(COSMOLOGY_REGISTRY)
+        raise ValueError(
+            f"Unsupported cosmology '{cosmo_name}'. "
+            f"Supported options are: {supported}"
+        )
+
+    entry = COSMOLOGY_REGISTRY[cosmo_name]
+    cosmo_cls = entry["class"]
+    unit_params = entry["unit_params"]
+    required = entry["required"]
+
+    # Collect all keys that are cosmology constructor arguments.
+    cosmo_kwargs = {k: v for k, v in special_option.items() if k not in _LOADER_KEYS}
+
+    # Validate required parameters.
+    missing = required - cosmo_kwargs.keys()
+    if missing:
+        raise ValueError(
+            f"Cosmology '{cosmo_name}' requires the following missing "
+            f"parameter(s): {', '.join(sorted(missing))}"
+        )
+
+    # Apply units to parameters that need them.
+    for param, unit in unit_params.items():
+        if param in cosmo_kwargs:
+            cosmo_kwargs[param] = cosmo_kwargs[param] * unit
+
+    return cosmo_cls(**cosmo_kwargs)

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -246,12 +246,12 @@ class ModelConfig(Config):
         ):
             for key, value in self.settings["kwargs_model"].items():
                 kwargs_model[key] = value
-                if (key == "multi_plane" and True):
-                        H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
-                        Om0 = self.settings["special_option"]["Om0"]
-                        cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
-                        kwargs_model.update({"cosmo": cosmo})
-        
+                if key == "multi_plane" and True:
+                    H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
+                    Om0 = self.settings["special_option"]["Om0"]
+                    cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
+                    kwargs_model.update({"cosmo": cosmo})
+
         return kwargs_model
 
     def get_kwargs_constraints(self, use_jax=False):

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -246,7 +246,13 @@ class ModelConfig(Config):
         ):
             for key, value in self.settings["kwargs_model"].items():
                 kwargs_model[key] = value
-
+                if (key == "multi_plane" and 
+                     value == True):
+                        H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
+                        Om0 = self.settings["special_option"]["Om0"]
+                        cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
+                        kwargs_model.update({"cosmo": cosmo})
+        
         return kwargs_model
 
     def get_kwargs_constraints(self, use_jax=False):

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -246,13 +246,12 @@ class ModelConfig(Config):
         ):
             for key, value in self.settings["kwargs_model"].items():
                 kwargs_model[key] = value
-                if (key == "multi_plane" and 
-                     value == True):
-                        H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
-                        Om0 = self.settings["special_option"]["Om0"]
-                        cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
-                        kwargs_model.update({"cosmo": cosmo})
-        
+                if key == "multi_plane" and value == True:
+                    H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
+                    Om0 = self.settings["special_option"]["Om0"]
+                    cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)
+                    kwargs_model.update({"cosmo": cosmo})
+
         return kwargs_model
 
     def get_kwargs_constraints(self, use_jax=False):

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -246,8 +246,7 @@ class ModelConfig(Config):
         ):
             for key, value in self.settings["kwargs_model"].items():
                 kwargs_model[key] = value
-                if (key == "multi_plane" and 
-                     value == True):
+                if (key == "multi_plane" and True):
                         H0 = self.settings["special_option"]["H0"] * u.km / u.s / u.Mpc
                         Om0 = self.settings["special_option"]["Om0"]
                         cosmo = FlatLambdaCDM(H0=H0, Om0=Om0, Ob0=None)

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -263,8 +263,7 @@ class ModelConfig(Config):
 
     @staticmethod
     def _get_cosmology_instance(special):
-        """
-        Build and return a cosmology instance from the "special_option" settings.
+        """Build and return a cosmology instance from the "special_option" settings.
 
         This is a helper method for backward compatibility with older config files that
         specified cosmology settings in "special_option" without the "cosmology" key. It
@@ -1790,8 +1789,7 @@ _LOADER_KEYS = {
 
 
 def _build_cosmology(special_option):
-    """
-    Build and return an astropy cosmology object from *special_option*.
+    """Build and return an astropy cosmology object from *special_option*.
 
     The ``cosmology`` key selects the model (default: ``"FlatLambdaCDM"``).
     All other keys are forwarded as constructor arguments, with unit

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -20,6 +20,10 @@ from astropy.cosmology import (
     wCDM,
     Flatw0waCDM,
     w0waCDM,
+    w0wzCDM,
+    Flatw0wzCDM,
+    wpwaCDM,
+    FlatwpwaCDM,
 )
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 
@@ -276,7 +280,7 @@ class ModelConfig(Config):
         :return: a cosmology instance
         :rtype: `astropy.cosmology.Cosmology` or `None`
         """
-        cosmo_keys = set(special) - _LOADER_KEYS
+        cosmo_keys = set(special) & _COSMOLOGY_KEYS
         cosmo = None
         if cosmo_keys:
             cosmo = _build_cosmology(special)
@@ -1775,16 +1779,54 @@ COSMOLOGY_REGISTRY = {
         },
         "required": {"H0", "Om0", "Ode0"},
     },
+    "w0wzCDM": {
+        "class": w0wzCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0", "Ode0", "w0", "wz"},
+    },
+    "Flatw0wzCDM": {
+        "class": Flatw0wzCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0", "w0", "wz"},
+    },
+    "wpwaCDM": {
+        "class": wpwaCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0", "Ode0", "wp", "wa", "zp"},
+    },
+    "FlatwpwaCDM": {
+        "class": FlatwpwaCDM,
+        "unit_params": {
+            "H0": u.km / u.s / u.Mpc,
+            "Tcmb0": u.K,
+        },
+        "required": {"H0", "Om0", "wp", "wa", "zp"},
+    },
 }
 
-# Parameters that are intentionally NOT forwarded to the cosmology constructor
-# (they are meta-keys used only by this loader).
-_LOADER_KEYS = {
-    "cosmology",
-    "delta_x_image",
-    "delta_y_image",
-    "delta_image_lower",
-    "delta_image_upper",
+# Parameters that are forwarded to the cosmology constructor
+_COSMOLOGY_KEYS = {
+    "H0",
+    "Om0",
+    "Ode0",
+    "Tcmb0",
+    "Neff",
+    "m_nu",
+    "Ob0",
+    "w0",
+    "wa",
+    "wz",
+    "wp",
+    "zp",
 }
 
 
@@ -1816,7 +1858,7 @@ def _build_cosmology(special_option):
     required = entry["required"]
 
     # Collect all keys that are cosmology constructor arguments.
-    cosmo_kwargs = {k: v for k, v in special_option.items() if k not in _LOADER_KEYS}
+    cosmo_kwargs = {k: v for k, v in special_option.items() if k in _COSMOLOGY_KEYS}
 
     # Validate required parameters.
     missing = required - cosmo_kwargs.keys()

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from dolphin.processor.config import Config
 from dolphin.processor.config import ModelConfig
+from dolphin.processor.config import _build_cosmology
 from dolphin.processor.files import FileSystem
 
 _ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -31,6 +32,68 @@ class TestConfig(object):
         )
         config = Config()
         config.load_config_from_yaml(str(test_setting_file.resolve()))
+
+    def test_build_cosmology(self):
+        """Test the `_build_cosmology` function."""
+        # Test default FlatLambdaCDM with loader keys filtered out
+        cosmo = _build_cosmology({"H0": 70, "Om0": 0.3, "delta_x_image": [0.01]})
+        assert type(cosmo).__name__ == "FlatLambdaCDM"
+        assert cosmo.H0.value == 70
+        assert cosmo.Om0 == 0.3
+
+        # Test LambdaCDM with Tcmb0
+        cosmo = _build_cosmology(
+            {
+                "cosmology": "LambdaCDM",
+                "H0": 72,
+                "Om0": 0.28,
+                "Ode0": 0.72,
+                "Tcmb0": 2.725,
+            }
+        )
+        assert type(cosmo).__name__ == "LambdaCDM"
+        assert cosmo.H0.value == 72
+        assert cosmo.Tcmb0.value == 2.725
+
+        # Test unsupported cosmology
+        with pytest.raises(
+            ValueError, match="Unsupported cosmology 'InvalidCosmo'"
+        ):
+            _build_cosmology({"cosmology": "InvalidCosmo", "H0": 70, "Om0": 0.3})
+
+        # Test missing required parameters
+        with pytest.raises(
+            ValueError, match="requires the following missing parameter"
+        ):
+            _build_cosmology({"cosmology": "LambdaCDM", "H0": 70, "Om0": 0.3})
+
+        # Test other models to ensure full registry functions
+        cosmo = _build_cosmology(
+            {"cosmology": "FlatwCDM", "H0": 70, "Om0": 0.3, "w0": -0.9}
+        )
+        assert type(cosmo).__name__ == "FlatwCDM"
+
+        cosmo = _build_cosmology(
+            {"cosmology": "wCDM", "H0": 70, "Om0": 0.3, "Ode0": 0.7, "w0": -0.9}
+        )
+        assert type(cosmo).__name__ == "wCDM"
+
+        cosmo = _build_cosmology(
+            {"cosmology": "Flatw0waCDM", "H0": 70, "Om0": 0.3, "w0": -0.9, "wa": 0.1}
+        )
+        assert type(cosmo).__name__ == "Flatw0waCDM"
+
+        cosmo = _build_cosmology(
+            {
+                "cosmology": "w0waCDM",
+                "H0": 70,
+                "Om0": 0.3,
+                "Ode0": 0.7,
+                "w0": -0.9,
+                "wa": 0.1,
+            }
+        )
+        assert type(cosmo).__name__ == "w0waCDM"
 
 
 class TestModelConfig(object):

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -92,6 +92,41 @@ class TestConfig(object):
             }
         )
         assert type(cosmo).__name__ == "w0waCDM"
+        
+        cosmo = _build_cosmology(
+            {"cosmology": "Flatw0wzCDM", "H0": 70, "Om0": 0.3, "w0": -0.9, "wz": 0.1}
+        )
+        assert type(cosmo).__name__ == "Flatw0wzCDM"
+
+        cosmo = _build_cosmology(
+            {
+                "cosmology": "w0wzCDM",
+                "H0": 70,
+                "Om0": 0.3,
+                "Ode0": 0.7,
+                "w0": -0.9,
+                "wz": 0.1,
+            }
+        )
+        assert type(cosmo).__name__ == "w0wzCDM"
+
+        cosmo = _build_cosmology(
+            {"cosmology": "FlatwpwaCDM", "H0": 70, "Om0": 0.3, "wp": -0.9, "wa": 0.1, "zp": 0.5}
+        )
+        assert type(cosmo).__name__ == "FlatwpwaCDM"
+
+        cosmo = _build_cosmology(
+            {
+                "cosmology": "wpwaCDM",
+                "H0": 70,
+                "Om0": 0.3,
+                "Ode0": 0.7,
+                "wp": -0.9,
+                "wa": 0.1,
+                "zp": 0.5,
+            }
+        )
+        assert type(cosmo).__name__ == "wpwaCDM"
 
 
 class TestModelConfig(object):

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -122,13 +122,8 @@ class TestModelConfig(object):
         assert kwargs_model_4["lens_model_list"] == ["EPL", "SHEAR_GAMMA_PSI"]
 
         config1 = deepcopy(self.config_1)
-        config1.settings["kwargs_model"] = {
-            "multi_plane": True
-        }
-        config1.settings["special_option"] = {
-            "H0": 70,
-            "Om0": 0.3
-        }
+        config1.settings["kwargs_model"] = {"multi_plane": True}
+        config1.settings["special_option"] = {"H0": 70, "Om0": 0.3}
         kwargs_model_1 = config1.get_kwargs_model()
         assert "cosmo" in kwargs_model_1
 

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -121,6 +121,17 @@ class TestModelConfig(object):
         kwargs_model_4 = self.config_4.get_kwargs_model()
         assert kwargs_model_4["lens_model_list"] == ["EPL", "SHEAR_GAMMA_PSI"]
 
+        config1 = deepcopy(self.config_1)
+        config1.settings["kwargs_model"] = {
+            "multi_plane": True
+        }
+        config1.settings["special_option"] = {
+            "H0": 70,
+            "Om0": 0.3
+        }
+        kwargs_model_1 = config1.get_kwargs_model()
+        assert "cosmo" in kwargs_model_1
+
     def test_get_kwargs_model_mge(self):
         """Test `get_kwargs_model` MGE_SET / MGE_SET_ELLIPSE handling."""
         # MGE_SET_ELLIPSE with explicit n_comp in mge_config

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -92,7 +92,7 @@ class TestConfig(object):
             }
         )
         assert type(cosmo).__name__ == "w0waCDM"
-        
+
         cosmo = _build_cosmology(
             {"cosmology": "Flatw0wzCDM", "H0": 70, "Om0": 0.3, "w0": -0.9, "wz": 0.1}
         )
@@ -111,7 +111,14 @@ class TestConfig(object):
         assert type(cosmo).__name__ == "w0wzCDM"
 
         cosmo = _build_cosmology(
-            {"cosmology": "FlatwpwaCDM", "H0": 70, "Om0": 0.3, "wp": -0.9, "wa": 0.1, "zp": 0.5}
+            {
+                "cosmology": "FlatwpwaCDM",
+                "H0": 70,
+                "Om0": 0.3,
+                "wp": -0.9,
+                "wa": 0.1,
+                "zp": 0.5,
+            }
         )
         assert type(cosmo).__name__ == "FlatwpwaCDM"
 

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -56,9 +56,7 @@ class TestConfig(object):
         assert cosmo.Tcmb0.value == 2.725
 
         # Test unsupported cosmology
-        with pytest.raises(
-            ValueError, match="Unsupported cosmology 'InvalidCosmo'"
-        ):
+        with pytest.raises(ValueError, match="Unsupported cosmology 'InvalidCosmo'"):
             _build_cosmology({"cosmology": "InvalidCosmo", "H0": 70, "Om0": 0.3})
 
         # Test missing required parameters

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -122,7 +122,6 @@ class TestModelConfig(object):
         assert kwargs_model_4["lens_model_list"] == ["EPL", "SHEAR_GAMMA_PSI"]
 
         config1 = deepcopy(self.config_1)
-        config1.settings["kwargs_model"] = {"multi_plane": True}
         config1.settings["special_option"] = {"H0": 70, "Om0": 0.3}
         kwargs_model_1 = config1.get_kwargs_model()
         assert "cosmo" in kwargs_model_1


### PR DESCRIPTION
This PR adds support for multi_plane lens modeling. The main change is that if ``multi_plane: True`` is found in ``kwargs_model`` from the config file, an instance of ``astropy.cosmology`` is added to ``kwargs_model`` based upon ``H0`` and ``Om0`` values provided under ``special_option``. The other multi_plane options required (e.g. ``lens_redshift_list``, ``z_source``, ``z_lens``, ``observed_convention_index``, etc.) are to be added by the user in the config file.