### PR TITLE
Add flexion lens mass model

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -53,7 +53,7 @@ Model Section
 
   - Suboptions:
 
-    - ``lens``: List of lens mass profiles. Supported models include: ``EPL``, ``SIE``, ``SIS``, ``SPEP``, ``PEMD``, ``SHEAR_GAMMA_PSI``.
+    - ``lens``: List of lens mass profiles. Supported models include: ``EPL``, ``SIE``, ``SIS``, ``SPEP``, ``PEMD``, ``SHEAR_GAMMA_PSI``, ``FLEXION``.
 
       - Type: ``list of strings``
       - Example:

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1232,7 +1232,7 @@ class ModelConfig(Config):
                         "g1": 0.01,
                         "g2": 0.01,
                         "g3": 0.01,
-                        "g4": 0.01,    
+                        "g4": 0.01,
                     }
                 )
                 lower.append(
@@ -1240,7 +1240,7 @@ class ModelConfig(Config):
                         "g1": -0.1,
                         "g2": -0.1,
                         "g3": -0.1,
-                        "g4": -0.1,                    
+                        "g4": -0.1,
                     }
                 )
                 upper.append(
@@ -1248,7 +1248,7 @@ class ModelConfig(Config):
                         "g1": 0.1,
                         "g2": 0.1,
                         "g3": 0.1,
-                        "g4": 0.1,                    
+                        "g4": 0.1,
                     }
                 )
             else:

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1217,6 +1217,40 @@ class ModelConfig(Config):
                         "center_y": center_y + bound,
                     }
                 )
+            elif model == "FLEXION":
+                fixed.append({"ra_0": 0, "dec_0": 0})
+                init.append(
+                    {
+                        "g1": 0,
+                        "g2": 0,
+                        "g3": 0,
+                        "g4": 0,
+                    }
+                )
+                sigma.append(
+                    {
+                        "g1": 0.01,
+                        "g2": 0.01,
+                        "g3": 0.01,
+                        "g4": 0.01,    
+                    }
+                )
+                lower.append(
+                    {
+                        "g1": -0.1,
+                        "g2": -0.1,
+                        "g3": -0.1,
+                        "g4": -0.1,                    
+                    }
+                )
+                upper.append(
+                    {
+                        "g1": 0.1,
+                        "g2": 0.1,
+                        "g3": 0.1,
+                        "g4": 0.1,                    
+                    }
+                )
             else:
                 raise ValueError("{} not implemented as a lens " "model!".format(model))
 

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -677,33 +677,20 @@ class TestModelConfig(object):
         config1 = deepcopy(self.config_1)
         config1.settings["model"]["lens"] = ["FLEXION"]
         params1 = config1.get_lens_model_params()
-        assert params1[0][0] == {
-            "g1": 0,
-            "g2": 0,
-            "g3": 0,
-            "g4": 0
-        }
-        assert params1[1][0] == {
-            "g1": 0.01,
-            "g2": 0.01,
-            "g3": 0.01,
-            "g4": 0.01
-        }
-        assert params1[2][0] == {
-            "ra_0": 0,
-            "dec_0": 0
-        }
+        assert params1[0][0] == {"g1": 0, "g2": 0, "g3": 0, "g4": 0}
+        assert params1[1][0] == {"g1": 0.01, "g2": 0.01, "g3": 0.01, "g4": 0.01}
+        assert params1[2][0] == {"ra_0": 0, "dec_0": 0}
         assert params1[3][0] == {
             "g1": -0.1,
             "g2": -0.1,
             "g3": -0.1,
-            "g4": -0.1,    
+            "g4": -0.1,
         }
         assert params1[4][0] == {
             "g1": 0.1,
             "g2": 0.1,
             "g3": 0.1,
-            "g4": 0.1,    
+            "g4": 0.1,
         }
 
     def test_get_lens_light_model_params(self):

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -674,6 +674,38 @@ class TestModelConfig(object):
             "theta_E": 0.1,
         }
 
+        config1 = deepcopy(self.config_1)
+        config1.settings["model"]["lens"] = ["FLEXION"]
+        params1 = config1.get_lens_model_params()
+        assert params1[0][0] == {
+            "g1": 0,
+            "g2": 0,
+            "g3": 0,
+            "g4": 0
+        }
+        assert params1[1][0] == {
+            "g1": 0.01,
+            "g2": 0.01,
+            "g3": 0.01,
+            "g4": 0.01
+        }
+        assert params1[2][0] == {
+            "ra_0": 0,
+            "dec_0": 0
+        }
+        assert params1[3][0] == {
+            "g1": -0.1,
+            "g2": -0.1,
+            "g3": -0.1,
+            "g4": -0.1,    
+        }
+        assert params1[4][0] == {
+            "g1": 0.1,
+            "g2": 0.1,
+            "g3": 0.1,
+            "g4": 0.1,    
+        }
+
     def test_get_lens_light_model_params(self):
         """Test `get_lens_light_model_params` method."""
         config = deepcopy(self.config_5)


### PR DESCRIPTION
This PR adds the required arguments, initialization, and testing for the ``FLEXION`` mass model. ``FLEXION`` accounts for second-order lensing distortions.