### PR TITLE
Add general_scaling special option support

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -468,10 +468,10 @@ Special Options
 
           Tcmb0: 2.725
 
-    - ``general_scaling``: Scale specific model parameters together across multiple profiles.
+    - ``general_scaling``: Scale specific model parameters together across multiple profiles. Input should be a dictionary mapping parameter names to the masks defining which lens models are scaled together.
 
       - Type: ``dictionary``
-      - Example:
+      - Example: Scaling ``theta_E`` for the second and third mass profiles together, but not the first.
 
         .. code-block:: yaml
 
@@ -479,10 +479,10 @@ Special Options
             theta_E:
               [False, 1, 1]
 
-    - ``{param_name}_scale_factor``: Defines the scaling relation factor for the specified `param_name` across multiple profiles.
-
+    - ``{param_name}_scale_factor``: The scaling relation factor for the specified `param_name` across multiple profiles. Instead of individually sampling the connected parameters, only this scale factor will be sampled, and all the connected parameters will be scaled based on the same factor.
+  
       - Type: ``list``
-      - Example
+      - Example:
 
         .. code-block:: yaml
 
@@ -491,7 +491,7 @@ Special Options
     - ``{param_name}_scale_factor_sigma``: Initial paramater spread relative to ``{param_name}_scale_factor``.
 
       - Type: ``list``
-      - Example
+      - Example:
 
         .. code-block:: yaml
 
@@ -500,11 +500,18 @@ Special Options
     - ``{param_name}_scale_pow``: Power-law scaling factor for the specified `param_name` scaling.
 
       - Type: ``list``
-      - Example
+      - Example:
 
         .. code-block:: yaml
 
           theta_E_scale_pow: [1]
+
+    - Combining all of the above, a specified parameter, :math:`p`, is scaled from the sampled scale factor, :math:`f_p`, and sampled power-law index, :math:`\alpha_p`, as:
+
+      .. math::
+
+        p \rightarrow p_{\mathrm{scaled}} =
+        f_p \, p^{\alpha_p}
 
 Guess Parameters
 ----------------

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -468,6 +468,44 @@ Special Options
 
           Tcmb0: 2.725
 
+    - ``general_scaling``: Scale specific model parameters together across multiple profiles.
+
+      - Type: ``dictionary``
+      - Example:
+
+        .. code-block:: yaml
+
+          general_scaling:
+            theta_E:
+              [False, 1, 1]
+
+    - ``{param_name}_scale_factor``: Defines the scaling relation factor for the specified `param_name` across multiple profiles.
+
+      - Type: ``list``
+      - Example
+
+        .. code-block:: yaml
+
+          theta_E_scale_factor: [1]
+
+    - ``{param_name}_scale_factor_sigma``: Initial paramater spread relative to ``{param_name}_scale_factor``.
+
+      - Type: ``list``
+      - Example
+
+        .. code-block:: yaml
+
+          theta_E_scale_factor_sigma: [0.05]
+
+    - ``{param_name}_scale_pow``: Power-law scaling factor for the specified `param_name` scaling.
+
+      - Type: ``list``
+      - Example
+
+        .. code-block:: yaml
+
+          theta_E_scale_pow: [1]
+
 Guess Parameters
 ----------------
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -351,6 +351,8 @@ class ModelConfig(Config):
             for i, model in enumerate(special_list):
                 if model == "astrometric_uncertainty":
                     kwargs_constraints.update({"point_source_offset": True})
+                if model == "general_scaling":
+                    kwargs_constraints.update({"general_scaling": self.settings["special_options"]["general_scaling"]})
                 if model == "time_delay_likelihood":
                     kwargs_constraints.update({"Ddt_sampling": True})
 
@@ -1102,6 +1104,10 @@ class ModelConfig(Config):
                     special_list.append("astrometric_uncertainty")
                 else:
                     raise ValueError(f"{model} not supported")
+            
+        if "special_options" in self.settings:
+                if "general_scaling" in self.settings["special_options"]:
+                    special_list.append("general_scaling")
 
         if "point_source_options" in self.settings:
             if (
@@ -1710,6 +1716,24 @@ class ModelConfig(Config):
                 )
 
                 fixed.update({})
+            elif model == "general_scaling":
+                general_scaling = self.settings["special_options"]["general_scaling"]
+
+                for param_name, values in general_scaling.items():
+                    if f"{param_name}_scale_factor" in self.settings["special_options"]:
+                        init.update({f"{param_name}_scale_factor": self.settings["special_options"][f"{param_name}_scale_factor"]})
+                    else:
+                        raise ValueError(f"{param_name}_scale_factor not found in special_options!")
+                    if f"{param_name}_scale_factor_sigma" in self.settings["special_options"]:
+                        sigma.update({f"{param_name}_scale_factor": self.settings["special_options"][f"{param_name}_scale_factor_sigma"]})
+                    else:
+                        raise ValueError(f"{param_name}_scale_factor_sigma not in special_options!")
+                    lower.update({f"{param_name}_scale_factor": [0.5 * self.settings["special_options"][f"{param_name}_scale_factor"][0]]})
+                    upper.update({f"{param_name}_scale_factor": [2.0 * self.settings["special_options"][f"{param_name}_scale_factor"][0]]})
+                    if f"{param_name}_scale_pow" in self.settings["special_options"]:
+                        fixed.update({f"{param_name}_scale_pow": self.settings["special_options"][f"{param_name}_scale_pow"]})
+                    else:
+                        raise ValueError(f"{param_name}_scale_pow not found in special_options!")
             elif model == "time_delay_likelihood":
                 special = self.settings["special_options"]
                 cosmo = self._get_cosmology_instance(special)

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -352,7 +352,13 @@ class ModelConfig(Config):
                 if model == "astrometric_uncertainty":
                     kwargs_constraints.update({"point_source_offset": True})
                 if model == "general_scaling":
-                    kwargs_constraints.update({"general_scaling": self.settings["special_options"]["general_scaling"]})
+                    kwargs_constraints.update(
+                        {
+                            "general_scaling": self.settings["special_options"][
+                                "general_scaling"
+                            ]
+                        }
+                    )
                 if model == "time_delay_likelihood":
                     kwargs_constraints.update({"Ddt_sampling": True})
 
@@ -1104,10 +1110,10 @@ class ModelConfig(Config):
                     special_list.append("astrometric_uncertainty")
                 else:
                     raise ValueError(f"{model} not supported")
-            
+
         if "special_options" in self.settings:
-                if "general_scaling" in self.settings["special_options"]:
-                    special_list.append("general_scaling")
+            if "general_scaling" in self.settings["special_options"]:
+                special_list.append("general_scaling")
 
         if "point_source_options" in self.settings:
             if (
@@ -1721,19 +1727,64 @@ class ModelConfig(Config):
 
                 for param_name, values in general_scaling.items():
                     if f"{param_name}_scale_factor" in self.settings["special_options"]:
-                        init.update({f"{param_name}_scale_factor": self.settings["special_options"][f"{param_name}_scale_factor"]})
+                        init.update(
+                            {
+                                f"{param_name}_scale_factor": self.settings[
+                                    "special_options"
+                                ][f"{param_name}_scale_factor"]
+                            }
+                        )
                     else:
-                        raise ValueError(f"{param_name}_scale_factor not found in special_options!")
-                    if f"{param_name}_scale_factor_sigma" in self.settings["special_options"]:
-                        sigma.update({f"{param_name}_scale_factor": self.settings["special_options"][f"{param_name}_scale_factor_sigma"]})
+                        raise ValueError(
+                            f"{param_name}_scale_factor not found in special_options!"
+                        )
+                    if (
+                        f"{param_name}_scale_factor_sigma"
+                        in self.settings["special_options"]
+                    ):
+                        sigma.update(
+                            {
+                                f"{param_name}_scale_factor": self.settings[
+                                    "special_options"
+                                ][f"{param_name}_scale_factor_sigma"]
+                            }
+                        )
                     else:
-                        raise ValueError(f"{param_name}_scale_factor_sigma not in special_options!")
-                    lower.update({f"{param_name}_scale_factor": [0.5 * self.settings["special_options"][f"{param_name}_scale_factor"][0]]})
-                    upper.update({f"{param_name}_scale_factor": [2.0 * self.settings["special_options"][f"{param_name}_scale_factor"][0]]})
+                        raise ValueError(
+                            f"{param_name}_scale_factor_sigma not in special_options!"
+                        )
+                    lower.update(
+                        {
+                            f"{param_name}_scale_factor": [
+                                0.5
+                                * self.settings["special_options"][
+                                    f"{param_name}_scale_factor"
+                                ][0]
+                            ]
+                        }
+                    )
+                    upper.update(
+                        {
+                            f"{param_name}_scale_factor": [
+                                2.0
+                                * self.settings["special_options"][
+                                    f"{param_name}_scale_factor"
+                                ][0]
+                            ]
+                        }
+                    )
                     if f"{param_name}_scale_pow" in self.settings["special_options"]:
-                        fixed.update({f"{param_name}_scale_pow": self.settings["special_options"][f"{param_name}_scale_pow"]})
+                        fixed.update(
+                            {
+                                f"{param_name}_scale_pow": self.settings[
+                                    "special_options"
+                                ][f"{param_name}_scale_pow"]
+                            }
+                        )
                     else:
-                        raise ValueError(f"{param_name}_scale_pow not found in special_options!")
+                        raise ValueError(
+                            f"{param_name}_scale_pow not found in special_options!"
+                        )
             elif model == "time_delay_likelihood":
                 special = self.settings["special_options"]
                 cosmo = self._get_cosmology_instance(special)

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -766,8 +766,14 @@ class TestModelConfig(object):
         # if specified in config file
         config = deepcopy(self.config_5)
         config.settings["model"]["special"] = ["astrometric_uncertainty"]
+        config.settings["special_options"] = {
+            "general_scaling": {
+                "theta_E": [False, 1, 1]
+            }
+        }
         assert config.get_special_list() == [
             "astrometric_uncertainty",
+            "general_scaling",
             "time_delay_likelihood",
         ]
 
@@ -905,7 +911,7 @@ class TestModelConfig(object):
     def test_get_special_params(self):
         """Test `get_special_params` method."""
 
-        # Test 1: ensure consistency of astrometric uncertainty params
+        # Test 1: ensure consistency of special params
         # if specified in config file
         config = deepcopy(self.config_5)
 
@@ -917,6 +923,12 @@ class TestModelConfig(object):
             "delta_image_upper": 0.004,
             "H0": 70,
             "Om0": 0.3,
+            "general_scaling": {
+                "theta_E": [False, 1, 1]
+            },
+            "theta_E_scale_factor": [1],
+            "theta_E_scale_factor_sigma": [0.05],
+            "theta_E_scale_pow": [1]
         }
 
         params = config.get_special_params()
@@ -941,12 +953,17 @@ class TestModelConfig(object):
         assert np.all(lower["delta_y_image"] == -0.004)
         assert np.all(upper["delta_y_image"] == 0.004)
 
+        assert init["theta_E_scale_factor"] == [1]
+        assert sigma["theta_E_scale_factor"] == [0.05]
+        assert lower["theta_E_scale_factor"] == [0.5]
+        assert upper["theta_E_scale_factor"] == [2]
+
         assert "D_dt" in init
         assert "D_dt" in sigma
         assert "D_dt" in lower
         assert "D_dt" in upper
 
-        assert fixed == {}
+        assert fixed == {"theta_E_scale_pow": [1]}
 
         # Test 2: ensure special params is empty list of dictionaries
         # if not specified in the config file
@@ -955,6 +972,19 @@ class TestModelConfig(object):
         params = config.get_special_params()
 
         assert params == [{}, {}, {}, {}, {}]
+
+        # Test 3: ensure proper error codes
+
+        config5 = deepcopy(self.config_5)
+
+        config5.settings["special_options"] = {
+            "general_scaling": {
+                "theta_E": [False, 1, 1]
+            }
+        }
+
+        with pytest.raises(ValueError):
+            config5.get_special_params()
 
     def test_fill_in_fixed_from_settings(self):
         """Test `fill_in_fixed_from_settings` method."""

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -334,10 +334,16 @@ class TestModelConfig(object):
 
         config_5 = deepcopy(self.config_5)
         config_5.settings["model"]["special"] = ["astrometric_uncertainty"]
+        config_5.settings["special_options"] = {
+            "general_scaling": {
+                "theta_E": [False, 1, 1]
+            }
+        }
 
         kwargs_constraints5 = config_5.get_kwargs_constraints()
         assert kwargs_constraints5["point_source_offset"]
         assert kwargs_constraints5["Ddt_sampling"]
+        assert kwargs_constraints5["general_scaling"]
 
     def test_get_kwargs_likelihood(self):
         """Test `get_kwargs_likelihood` method."""
@@ -980,6 +986,20 @@ class TestModelConfig(object):
         with pytest.raises(ValueError):
             config5.get_special_params()
 
+        config5.settings["special_options"].update({
+            "theta_E_scale_factor": [1]
+        })
+
+        with pytest.raises(ValueError):
+            config5.get_special_params()
+
+        config5.settings["special_options"].update({
+            "theta_E_scale_factor_sigma": [0.05]
+        })
+
+        with pytest.raises(ValueError):
+            config5.get_special_params()
+    
     def test_fill_in_fixed_from_settings(self):
         """Test `fill_in_fixed_from_settings` method."""
         fixed = [{}]

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -767,9 +767,7 @@ class TestModelConfig(object):
         config = deepcopy(self.config_5)
         config.settings["model"]["special"] = ["astrometric_uncertainty"]
         config.settings["special_options"] = {
-            "general_scaling": {
-                "theta_E": [False, 1, 1]
-            }
+            "general_scaling": {"theta_E": [False, 1, 1]}
         }
         assert config.get_special_list() == [
             "astrometric_uncertainty",
@@ -923,12 +921,10 @@ class TestModelConfig(object):
             "delta_image_upper": 0.004,
             "H0": 70,
             "Om0": 0.3,
-            "general_scaling": {
-                "theta_E": [False, 1, 1]
-            },
+            "general_scaling": {"theta_E": [False, 1, 1]},
             "theta_E_scale_factor": [1],
             "theta_E_scale_factor_sigma": [0.05],
-            "theta_E_scale_pow": [1]
+            "theta_E_scale_pow": [1],
         }
 
         params = config.get_special_params()
@@ -978,9 +974,7 @@ class TestModelConfig(object):
         config5 = deepcopy(self.config_5)
 
         config5.settings["special_options"] = {
-            "general_scaling": {
-                "theta_E": [False, 1, 1]
-            }
+            "general_scaling": {"theta_E": [False, 1, 1]}
         }
 
         with pytest.raises(ValueError):

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -335,9 +335,7 @@ class TestModelConfig(object):
         config_5 = deepcopy(self.config_5)
         config_5.settings["model"]["special"] = ["astrometric_uncertainty"]
         config_5.settings["special_options"] = {
-            "general_scaling": {
-                "theta_E": [False, 1, 1]
-            }
+            "general_scaling": {"theta_E": [False, 1, 1]}
         }
 
         kwargs_constraints5 = config_5.get_kwargs_constraints()
@@ -986,20 +984,18 @@ class TestModelConfig(object):
         with pytest.raises(ValueError):
             config5.get_special_params()
 
-        config5.settings["special_options"].update({
-            "theta_E_scale_factor": [1]
-        })
+        config5.settings["special_options"].update({"theta_E_scale_factor": [1]})
 
         with pytest.raises(ValueError):
             config5.get_special_params()
 
-        config5.settings["special_options"].update({
-            "theta_E_scale_factor_sigma": [0.05]
-        })
+        config5.settings["special_options"].update(
+            {"theta_E_scale_factor_sigma": [0.05]}
+        )
 
         with pytest.raises(ValueError):
             config5.get_special_params()
-    
+
     def test_fill_in_fixed_from_settings(self):
         """Test `fill_in_fixed_from_settings` method."""
         fixed = [{}]


### PR DESCRIPTION
This pull request adds support for the ``general_scaling`` option. In ``Lenstronomy``, ``general_scaling`` allows one to scale specified parameters together across multiple profiles. The updates are as follows:

1) ``config.py``: Add ``general_scaling`` to the special list if it is detected in the config file. Iterate through the ``general_scaling`` dictionary to create proper special_param structure and return flags as needed.
2) ``test_config.py``: Appropriate modifications to the special test functions to ensure all new features are covered.
3) ``CONFIG_OPTIONS.rst``: Appropriate documentation detailing the implementation and functionality of the new scaling features.