### PR TITLE
Update/lenstronomy compatibility

### DIFF
--- a/ai_training/dataset.py
+++ b/ai_training/dataset.py
@@ -242,7 +242,7 @@ class TrainingData(object):
             }
 
             sim_api = SimAPI(
-                numpix=self.num_pixel,
+                num_pix=self.num_pixel,
                 kwargs_single_band=self.filter_settings,
                 kwargs_model=kwargs_model,
             )
@@ -251,7 +251,7 @@ class TrainingData(object):
 
             kwargs_model_copy["source_light_model_list"] = ["SERSIC_ELLIPSE"]
             sim_api_smooth_source = SimAPI(
-                numpix=self.num_pixel,
+                num_pix=self.num_pixel,
                 kwargs_single_band=self.filter_settings,
                 kwargs_model=kwargs_model_copy,
             )

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -232,7 +232,6 @@ class Output(Processor):
         model_id=None,
         kwargs_result=None,
         band_index=0,
-        data_cmap="cubehelix",
     ):
         """Get the `ModelPlot` instance from lenstronomy for the lens.
 
@@ -278,8 +277,6 @@ class Output(Processor):
             multi_band_list_out,
             kwargs_model,
             kwargs_result,
-            arrow_size=0.02,
-            cmap_string=data_cmap,
             image_likelihood_mask_list=mask,
             multi_band_type="multi-linear",
         )
@@ -295,10 +292,10 @@ class Output(Processor):
         residual_cmap="RdBu_r",
         convergence_cmap="afmhot",
         magnification_cmap="viridis",
-        v_min=None,
-        v_max=None,
-        source_v_min=None,
-        source_v_max=None,
+        vmin=None,
+        vmax=None,
+        source_vmin=None,
+        source_vmax=None,
         print_results=False,
         show_source_light=False,
     ):
@@ -325,14 +322,14 @@ class Output(Processor):
         :type convergence_cmap: `str` or `matplotlib.colors.Colormap`
         :param magnification_cmap: colormap for magnification plot
         :type magnification_cmap: `str` or `matplotlib.colors.Colormap`
-        :param v_min: minimum plotting scale for the model & data plots
-        :type v_min: `float` or `int` or `None`
-        :param v_max: maximum plotting scale for the model & data plots
-        :type v_max: `float` or `int` or `None`
-        :param source_v_min: minimum plotting scale for the source plot
-        :type source_v_min: `float` or `int` or `None`
-        :param source_v_max: maximum plotting scale for the source plot
-        :type source_v_max: `float` or `int` or `None`
+        :param vmin: minimum plotting scale for the model & data plots
+        :type vmin: `float` or `int` or `None`
+        :param vmax: maximum plotting scale for the model & data plots
+        :type vmax: `float` or `int` or `None`
+        :param source_vmin: minimum plotting scale for the source plot
+        :type source_vmin: `float` or `int` or `None`
+        :param source_vmax: maximum plotting scale for the source plot
+        :type source_vmax: `float` or `int` or `None`
         :param print_results: if `True`, prints the `kwargs_result` dictionary
         :type print_results: `bool`
         :param show_source_light: if `True`, replaces convergence plot with source light convolved lens decomposition plot and also replaces the magnification plot with the source-light subtracted data plot
@@ -348,13 +345,12 @@ class Output(Processor):
                 ]
             print(print_kwargs_result)
 
-        if v_max is None:
-            model_plot, v_max = self.get_model_plot_instance(
+        if vmax is None:
+            model_plot, vmax = self.get_model_plot_instance(
                 lens_name,
                 model_id=model_id,
                 kwargs_result=kwargs_result,
                 band_index=band_index,
-                data_cmap=data_cmap,
             )
         else:
             model_plot = self.get_model_plot_instance(
@@ -362,51 +358,48 @@ class Output(Processor):
                 model_id=model_id,
                 kwargs_result=kwargs_result,
                 band_index=band_index,
-                data_cmap=data_cmap,
             )[0]
 
         fig, axes = plt.subplots(2, 3, figsize=(16, 8))
 
         model_plot.data_plot(
-            ax=axes[0, 0], band_index=band_index, v_max=v_max, v_min=v_min
+            ax=axes[0, 0],
+            band_index=band_index,
         )
         model_plot.model_plot(
-            ax=axes[0, 1], band_index=band_index, v_max=v_max, v_min=v_min
+            ax=axes[0, 1],
+            band_index=band_index,
         )
         model_plot.normalized_residual_plot(
-            ax=axes[0, 2], band_index=band_index, cmap=residual_cmap, v_max=3, v_min=-3
+            ax=axes[0, 2],
+            band_index=band_index,
         )
         model_plot.source_plot(
             ax=axes[1, 0],
             deltaPix_source=0.02,
             numPix=100,
             band_index=band_index,
-            v_max=source_v_max,
-            v_min=source_v_min,
-            scale_size=0.4,
+            vmax=source_vmax,
+            vmin=source_vmin,
         )
         if not show_source_light:
-            model_plot.convergence_plot(
-                ax=axes[1, 1], band_index=band_index, cmap=convergence_cmap
-            )
-            model_plot.magnification_plot(
-                ax=axes[1, 2], band_index=band_index, cmap=magnification_cmap
-            )
+            model_plot.convergence_plot(ax=axes[1, 1], band_index=band_index)
+            model_plot.magnification_plot(ax=axes[1, 2], band_index=band_index)
         else:
             model_plot.subtract_from_data_plot(
                 ax=axes[1, 1],
                 band_index=band_index,
                 lens_light_add=True,
-                v_max=v_max,
-                v_min=v_min,
+                vmax=vmax,
+                vmin=vmin,
             )
             model_plot.decomposition_plot(
                 ax=axes[1, 2],
                 text="Source light convolved",
                 source_add=True,
                 band_index=band_index,
-                v_max=v_max,
-                v_min=v_min,
+                vmax=vmax,
+                vmin=vmin,
             )
         fig.tight_layout()
         fig.subplots_adjust(
@@ -422,8 +415,8 @@ class Output(Processor):
         kwargs_result=None,
         band_index=0,
         data_cmap="cubehelix",
-        v_min=None,
-        v_max=None,
+        vmin=None,
+        vmax=None,
     ):
         """Plot lens light and source light model decomposition, both with convolved and
         unconvolved light. Either `model_id` or `kwargs_result` needs to be provided.
@@ -442,16 +435,16 @@ class Output(Processor):
         :type band_index: `int`
         :param data_cmap: colormap for image, reconstruction, and source plots
         :type data_cmap: `str` or `matplotlib.colors.Colormap`
-        :param v_min: minimum plotting scale for the component plots
-        :type v_min: `float` or `int` or `None`
-        :param v_max: maximum plotting scale for the component plots
-        :type v_max: `float` or `int` or `None`
+        :param vmin: minimum plotting scale for the component plots
+        :type vmin: `float` or `int` or `None`
+        :param vmax: maximum plotting scale for the component plots
+        :type vmax: `float` or `int` or `None`
         :return: `matplotlib.figure.Figure` instance with the plots
         :rtype: `matplotlib.figure.Figure`
         """
 
-        if v_max is None:
-            model_plot, v_max = self.get_model_plot_instance(
+        if vmax is None:
+            model_plot, vmax = self.get_model_plot_instance(
                 lens_name,
                 model_id=model_id,
                 kwargs_result=kwargs_result,
@@ -474,16 +467,16 @@ class Output(Processor):
             lens_light_add=True,
             unconvolved=True,
             band_index=band_index,
-            v_max=v_max,
-            v_min=v_min,
+            vmax=vmax,
+            vmin=vmin,
         )
         model_plot.decomposition_plot(
             ax=axes[1, 0],
             text="Lens light convolved",
             lens_light_add=True,
             band_index=band_index,
-            v_max=v_max,
-            v_min=v_min,
+            vmax=vmax,
+            vmin=vmin,
         )
         model_plot.decomposition_plot(
             ax=axes[0, 1],
@@ -491,16 +484,16 @@ class Output(Processor):
             source_add=True,
             unconvolved=True,
             band_index=band_index,
-            v_max=v_max,
-            v_min=v_min,
+            vmax=vmax,
+            vmin=vmin,
         )
         model_plot.decomposition_plot(
             ax=axes[1, 1],
             text="Source light convolved",
             source_add=True,
             band_index=band_index,
-            v_max=v_max,
-            v_min=v_min,
+            vmax=vmax,
+            vmin=vmin,
         )
         model_plot.decomposition_plot(
             ax=axes[0, 2],
@@ -509,8 +502,8 @@ class Output(Processor):
             lens_light_add=True,
             unconvolved=True,
             band_index=band_index,
-            v_max=v_max,
-            v_min=v_min,
+            vmax=vmax,
+            vmin=vmin,
         )
         model_plot.decomposition_plot(
             ax=axes[1, 2],
@@ -519,8 +512,8 @@ class Output(Processor):
             lens_light_add=True,
             point_source_add=True,
             band_index=band_index,
-            v_max=v_max,
-            v_min=v_min,
+            vmax=vmax,
+            vmin=vmin,
         )
         fig.tight_layout()
         fig.subplots_adjust(

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -300,6 +300,8 @@ class Output(Processor):
         kwargs_source_plot=None,
         kwargs_convergence_plot=None,
         kwargs_magnification_plot=None,
+        kwargs_subtract_lens_light_plot=None,
+        kwargs_reconstructed_source_plot=None,
     ):
         """Plot the model, residual, reconstructed source, convergence, and
         magnification profiles. Either `model_id` or `kwargs_result` needs to be
@@ -348,6 +350,10 @@ class Output(Processor):
         :type kwargs_convergence_plot: `dict`
         :param kwargs_magnification_plot: kwargs for the magnification plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.magnification_plot()` for available keywords.
         :type kwargs_magnification_plot: `dict`
+        :param kwargs_subtract_lens_light_plot: kwargs for the subtracted lens light plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.subtract_from_data_plot()` for available keywords.
+        :type kwargs_subtract_lens_light_plot: `dict`
+        :param kwargs_reconstructed_source_plot: kwargs for the reconstructed source plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.decomposition_plot()` for available keywords.
+        :type kwargs_reconstructed_source_plot: `dict`
         :return: `matplotlib.figure.Figure` instance with the plots
         :rtype: `matplotlib.figure.Figure`
         """
@@ -374,16 +380,22 @@ class Output(Processor):
                 band_index=band_index,
             )[0]
 
-        for kwargs in [
-            kwargs_data_plot,
-            kwargs_model_plot,
-            kwargs_residual_plot,
-            kwargs_convergence_plot,
-            kwargs_magnification_plot,
-            kwargs_source_plot,
-        ]:
-            if kwargs is None:
-                kwargs = {}
+        if kwargs_data_plot is None:
+            kwargs_data_plot = {}
+        if kwargs_model_plot is None:
+            kwargs_model_plot = {}
+        if kwargs_residual_plot is None:
+            kwargs_residual_plot = {}
+        if kwargs_convergence_plot is None:
+            kwargs_convergence_plot = {}
+        if kwargs_magnification_plot is None:
+            kwargs_magnification_plot = {}
+        if kwargs_source_plot is None:
+            kwargs_source_plot = {}
+        if kwargs_subtract_lens_light_plot is None:
+            kwargs_subtract_lens_light_plot = {}
+        if kwargs_reconstructed_source_plot is None:
+            kwargs_reconstructed_source_plot = {}
 
         fig, axes = plt.subplots(2, 3, figsize=(16, 8))
 
@@ -421,20 +433,30 @@ class Output(Processor):
                 ax=axes[1, 2], band_index=band_index, **kwargs_magnification_plot
             )
         else:
+            kwargs_subtract_lens_light_plot.setdefault("kwargs_title", {})
+            kwargs_subtract_lens_light_plot["kwargs_title"].setdefault(
+                {"title": "Data - Lens Light"}
+            )
             model_plot.subtract_from_data_plot(
                 ax=axes[1, 1],
                 band_index=band_index,
                 lens_light_add=True,
                 vmax=vmax,
                 vmin=vmin,
+                **kwargs_subtract_lens_light_plot,
+            )
+
+            kwargs_reconstructed_source_plot.setdefault("kwargs_title", {})
+            kwargs_reconstructed_source_plot["kwargs_title"].setdefault(
+                {"title": "Reconstructed Source"}
             )
             model_plot.decomposition_plot(
                 ax=axes[1, 2],
-                text="Source light convolved",
                 source_add=True,
                 band_index=band_index,
-                vmax=vmax,
-                vmin=vmin,
+                vmax=source_vmax,
+                vmin=source_vmin,
+                **kwargs_reconstructed_source_plot,
             )
         fig.tight_layout()
         fig.subplots_adjust(
@@ -487,7 +509,6 @@ class Output(Processor):
                 model_id=model_id,
                 kwargs_result=kwargs_result,
                 band_index=band_index,
-                data_cmap=data_cmap,
             )
         else:
             model_plot = self.get_model_plot_instance(
@@ -495,7 +516,6 @@ class Output(Processor):
                 model_id=model_id,
                 kwargs_result=kwargs_result,
                 band_index=band_index,
-                data_cmap=data_cmap,
             )[0]
 
         if kwargs_decomposition_plot is None:
@@ -504,7 +524,6 @@ class Output(Processor):
         fig, axes = plt.subplots(2, 3, figsize=(16, 8))
         model_plot.decomposition_plot(
             ax=axes[0, 0],
-            text="Lens light",
             lens_light_add=True,
             unconvolved=True,
             band_index=band_index,
@@ -512,18 +531,18 @@ class Output(Processor):
             vmin=vmin,
             **kwargs_decomposition_plot,
         )
+        axes[0, 0].set_title("Lens light")
         model_plot.decomposition_plot(
             ax=axes[1, 0],
-            text="Lens light convolved",
             lens_light_add=True,
             band_index=band_index,
             vmax=vmax,
             vmin=vmin,
             **kwargs_decomposition_plot,
         )
+        axes[1, 0].set_title("Lens light convolved")
         model_plot.decomposition_plot(
             ax=axes[0, 1],
-            text="Source light",
             source_add=True,
             unconvolved=True,
             band_index=band_index,
@@ -531,18 +550,18 @@ class Output(Processor):
             vmin=vmin,
             **kwargs_decomposition_plot,
         )
+        axes[0, 1].set_title("Source light")
         model_plot.decomposition_plot(
             ax=axes[1, 1],
-            text="Source light convolved",
             source_add=True,
             band_index=band_index,
             vmax=vmax,
             vmin=vmin,
             **kwargs_decomposition_plot,
         )
+        axes[1, 1].set_title("Source light convolved")
         model_plot.decomposition_plot(
             ax=axes[0, 2],
-            text="All components",
             source_add=True,
             lens_light_add=True,
             unconvolved=True,
@@ -551,9 +570,9 @@ class Output(Processor):
             vmin=vmin,
             **kwargs_decomposition_plot,
         )
+        axes[0, 2].set_title("All components")
         model_plot.decomposition_plot(
             ax=axes[1, 2],
-            text="All components convolved",
             source_add=True,
             lens_light_add=True,
             point_source_add=True,
@@ -562,6 +581,7 @@ class Output(Processor):
             vmin=vmin,
             **kwargs_decomposition_plot,
         )
+        axes[1, 2].set_title("All components convolved")
         fig.tight_layout()
         fig.subplots_adjust(
             left=None, bottom=None, right=None, top=None, wspace=0.0, hspace=0.05

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -406,8 +406,8 @@ class Output(Processor):
         )
         model_plot.source_plot(
             ax=axes[1, 0],
-            deltaPix_source=0.02,
-            numPix=100,
+            delta_pix_source=0.02,
+            num_pix=100,
             band_index=band_index,
             vmax=source_vmax,
             vmin=source_vmin,
@@ -887,8 +887,8 @@ class Output(Processor):
         delta_pix = image_pixel_size / 2
         num_pix = source_lensed.shape[0]
         source_unlensed = model_plot.source(
-            deltaPix=delta_pix,
-            numPix=num_pix,
+            delta_pix=delta_pix,
+            num_pix=num_pix,
             band_index=band_index,
             center=[
                 kwargs_result["kwargs_source"][0]["center_x"],

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -985,7 +985,7 @@ class Output(Processor):
         kwargs_model = config.get_kwargs_model()
 
         lens_model_class = LensModel(lens_model_list=kwargs_model["lens_model_list"])
-        lensEquationSolver = LensEquationSolver(lens_model_class)
+        lens_equation_solver = LensEquationSolver(lens_model_class)
         x_source = kwargs_result["kwargs_source"][0]["center_x"]
         y_source = kwargs_result["kwargs_source"][0]["center_y"]
 
@@ -997,7 +997,7 @@ class Output(Processor):
         image_data = multi_band_list_out[band_index][0]["image_data"]
         image_size = image_data.shape[0] * image_pixel_size
 
-        x_image, y_image = lensEquationSolver.findBrightImage(
+        x_image, y_image = lens_equation_solver.find_bright_image(
             x_source,
             y_source,
             kwargs_lens,

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -288,16 +288,18 @@ class Output(Processor):
         model_id=None,
         kwargs_result=None,
         band_index=0,
-        data_cmap="cubehelix",
-        residual_cmap="RdBu_r",
-        convergence_cmap="afmhot",
-        magnification_cmap="viridis",
         vmin=None,
         vmax=None,
         source_vmin=None,
         source_vmax=None,
         print_results=False,
         show_source_light=False,
+        kwargs_data_plot=None,
+        kwargs_model_plot=None,
+        kwargs_residual_plot=None,
+        kwargs_source_plot=None,
+        kwargs_convergence_plot=None,
+        kwargs_magnification_plot=None,
     ):
         """Plot the model, residual, reconstructed source, convergence, and
         magnification profiles. Either `model_id` or `kwargs_result` needs to be
@@ -334,6 +336,18 @@ class Output(Processor):
         :type print_results: `bool`
         :param show_source_light: if `True`, replaces convergence plot with source light convolved lens decomposition plot and also replaces the magnification plot with the source-light subtracted data plot
         :type show_source_light: `bool`
+        :param kwargs_data_plot: kwargs for the data plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.data_plot()` for available keywords.
+        :type kwargs_data_plot: `dict`
+        :param kwargs_model_plot: kwargs for the model plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.model_plot()` for available keywords.
+        :type kwargs_model_plot: `dict`
+        :param kwargs_residual_plot: kwargs for the residual plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.normalized_residual_plot()` for available keywords.
+        :type kwargs_residual_plot: `dict`
+        :param kwargs_source_plot: kwargs for the source plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.source_plot()` for available keywords.
+        :type kwargs_source_plot: `dict`
+        :param kwargs_convergence_plot: kwargs for the convergence plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.convergence_plot()` for available keywords.
+        :type kwargs_convergence_plot: `dict`
+        :param kwargs_magnification_plot: kwargs for the magnification plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.magnification_plot()` for available keywords.
+        :type kwargs_magnification_plot: `dict`
         :return: `matplotlib.figure.Figure` instance with the plots
         :rtype: `matplotlib.figure.Figure`
         """
@@ -360,19 +374,35 @@ class Output(Processor):
                 band_index=band_index,
             )[0]
 
+        for kwargs in [
+            kwargs_data_plot,
+            kwargs_model_plot,
+            kwargs_residual_plot,
+            kwargs_convergence_plot,
+            kwargs_magnification_plot,
+            kwargs_source_plot,
+        ]:
+            if kwargs is None:
+                kwargs = {}
+
         fig, axes = plt.subplots(2, 3, figsize=(16, 8))
 
         model_plot.data_plot(
             ax=axes[0, 0],
             band_index=band_index,
+            vmin=vmin,
+            vmax=vmax,
+            **kwargs_data_plot,
         )
         model_plot.model_plot(
             ax=axes[0, 1],
             band_index=band_index,
+            vmin=vmin,
+            vmax=vmax,
+            **kwargs_model_plot,
         )
         model_plot.normalized_residual_plot(
-            ax=axes[0, 2],
-            band_index=band_index,
+            ax=axes[0, 2], band_index=band_index, **kwargs_residual_plot
         )
         model_plot.source_plot(
             ax=axes[1, 0],
@@ -381,10 +411,15 @@ class Output(Processor):
             band_index=band_index,
             vmax=source_vmax,
             vmin=source_vmin,
+            **kwargs_source_plot,
         )
         if not show_source_light:
-            model_plot.convergence_plot(ax=axes[1, 1], band_index=band_index)
-            model_plot.magnification_plot(ax=axes[1, 2], band_index=band_index)
+            model_plot.convergence_plot(
+                ax=axes[1, 1], band_index=band_index, **kwargs_convergence_plot
+            )
+            model_plot.magnification_plot(
+                ax=axes[1, 2], band_index=band_index, **kwargs_magnification_plot
+            )
         else:
             model_plot.subtract_from_data_plot(
                 ax=axes[1, 1],

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -440,7 +440,7 @@ class Output(Processor):
             model_plot.subtract_from_data_plot(
                 ax=axes[1, 1],
                 band_index=band_index,
-                lens_light_add=True,
+                subtract_lens_light=True,
                 vmax=vmax,
                 vmin=vmin,
                 **kwargs_subtract_lens_light_plot,

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -435,7 +435,7 @@ class Output(Processor):
         else:
             kwargs_subtract_lens_light_plot.setdefault("kwargs_title", {})
             kwargs_subtract_lens_light_plot["kwargs_title"].setdefault(
-                {"title": "Data - Lens Light"}
+                "title", "Data - Lens Light"
             )
             model_plot.subtract_from_data_plot(
                 ax=axes[1, 1],
@@ -448,7 +448,7 @@ class Output(Processor):
 
             kwargs_reconstructed_source_plot.setdefault("kwargs_title", {})
             kwargs_reconstructed_source_plot["kwargs_title"].setdefault(
-                {"title": "Reconstructed Source"}
+                "title", "Reconstructed Source"
             )
             model_plot.decomposition_plot(
                 ax=axes[1, 2],

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -452,6 +452,7 @@ class Output(Processor):
         data_cmap="cubehelix",
         vmin=None,
         vmax=None,
+        kwargs_decomposition_plot=None,
     ):
         """Plot lens light and source light model decomposition, both with convolved and
         unconvolved light. Either `model_id` or `kwargs_result` needs to be provided.
@@ -474,6 +475,8 @@ class Output(Processor):
         :type vmin: `float` or `int` or `None`
         :param vmax: maximum plotting scale for the component plots
         :type vmax: `float` or `int` or `None`
+        :param kwargs_decomposition_plot: additional keyword arguments for the decomposition plots, see :func: `lenstronomy.Plots.model_plot.ModelPlot.decomposition_plot()` for available keywords.
+        :type kwargs_decomposition_plot: `dict`
         :return: `matplotlib.figure.Figure` instance with the plots
         :rtype: `matplotlib.figure.Figure`
         """
@@ -495,6 +498,9 @@ class Output(Processor):
                 data_cmap=data_cmap,
             )[0]
 
+        if kwargs_decomposition_plot is None:
+            kwargs_decomposition_plot = {}
+
         fig, axes = plt.subplots(2, 3, figsize=(16, 8))
         model_plot.decomposition_plot(
             ax=axes[0, 0],
@@ -504,6 +510,7 @@ class Output(Processor):
             band_index=band_index,
             vmax=vmax,
             vmin=vmin,
+            **kwargs_decomposition_plot,
         )
         model_plot.decomposition_plot(
             ax=axes[1, 0],
@@ -512,6 +519,7 @@ class Output(Processor):
             band_index=band_index,
             vmax=vmax,
             vmin=vmin,
+            **kwargs_decomposition_plot,
         )
         model_plot.decomposition_plot(
             ax=axes[0, 1],
@@ -521,6 +529,7 @@ class Output(Processor):
             band_index=band_index,
             vmax=vmax,
             vmin=vmin,
+            **kwargs_decomposition_plot,
         )
         model_plot.decomposition_plot(
             ax=axes[1, 1],
@@ -529,6 +538,7 @@ class Output(Processor):
             band_index=band_index,
             vmax=vmax,
             vmin=vmin,
+            **kwargs_decomposition_plot,
         )
         model_plot.decomposition_plot(
             ax=axes[0, 2],
@@ -539,6 +549,7 @@ class Output(Processor):
             band_index=band_index,
             vmax=vmax,
             vmin=vmin,
+            **kwargs_decomposition_plot,
         )
         model_plot.decomposition_plot(
             ax=axes[1, 2],
@@ -549,6 +560,7 @@ class Output(Processor):
             band_index=band_index,
             vmax=vmax,
             vmin=vmin,
+            **kwargs_decomposition_plot,
         )
         fig.tight_layout()
         fig.subplots_adjust(

--- a/test/test_analysis/test_output.py
+++ b/test/test_analysis/test_output.py
@@ -208,8 +208,8 @@ class TestOutput(object):
         fig2 = self.output.plot_model_overview(
             "lens_system2",
             "example",
-            v_min=-3.0,
-            v_max=1.0,
+            vmin=-3.0,
+            vmax=1.0,
             print_results=True,
             show_source_light=True,
         )
@@ -230,7 +230,7 @@ class TestOutput(object):
         plt.close(fig)
 
         fig2 = self.output.plot_model_decomposition(
-            "lens_system2", "example", v_min=-3.0, v_max=1.0
+            "lens_system2", "example", vmin=-3.0, vmax=1.0
         )
 
         plt.close(fig2)


### PR DESCRIPTION
This pull request refactors plotting functions in `dolphin/analysis/output.py` to for compatibility with `lenstronomy` after https://github.com/lenstronomy/lenstronomy/pull/847. 

The main changes include standardizing parameter naming (e.g., `v_min`/`v_max` to `vmin`/`vmax`), removing hardcoded colormap arguments, and adding new keyword arguments to allow users to pass additional plotting options directly to underlying plotting functions. Some variable names have also been updated for consistency, and corresponding test cases have been adjusted.

**API and Parameter Improvements:**

* Standardized plotting parameter names from `v_min`/`v_max` to `vmin`/`vmax` across `plot_model_overview` and `plot_model_decomposition`, and updated their usage and documentation accordingly. [[1]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L294-R302) [[2]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L328-R350) [[3]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L425-R455) [[4]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L445-R485) [[5]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3L211-R212) [[6]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3L233-R233)
* Removed hardcoded colormap parameters (`data_cmap`, `residual_cmap`, `convergence_cmap`, `magnification_cmap`) from plotting function signatures, and replaced them with more flexible `kwargs_*_plot` keyword arguments for each plot type. [[1]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L294-R302) [[2]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L328-R350) [[3]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L351-R437) [[4]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L425-R455) [[5]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L445-R485) [[6]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575R501-R541) [[7]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L512-R552) [[8]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L522-R563)
* Added new `kwargs_*_plot` parameters (e.g., `kwargs_data_plot`, `kwargs_model_plot`, etc.) to both main plotting functions, allowing users to pass arbitrary keyword arguments to the underlying `lenstronomy` plotting methods. [[1]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L294-R302) [[2]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L328-R350) [[3]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L351-R437) [[4]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L425-R455) [[5]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L445-R485) [[6]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575R501-R541) [[7]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L512-R552) [[8]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L522-R563)

**Internal Consistency and Refactoring:**

* Updated variable names for consistency with Python naming conventions (e.g., `lensEquationSolver` to `lens_equation_solver`, and `findBrightImage` to `find_bright_image`). [[1]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L995-R1035) [[2]](diffhunk://#diff-610531bafa77153bd653f9c3f89056e4b22fbb48a2a463dba6759ea9b6586575L1007-R1047)
* Updated test cases in `test/test_analysis/test_output.py` to use the new standardized parameter names. [[1]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3L211-R212) [[2]](diffhunk://#diff-6e9f3fa12f4b6f983c7f7a76125318f54b6eaba0ed8793f6c76aae18292deae3L233-R233)