### PR TITLE
Add framework for custom uniform priors

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -238,7 +238,7 @@ Lens Light Options
              0: 
                [[R_sersic, 0.21, 0.15]]
 
-    - ``uniform_prior``: *(Optional)* Adjust dolphin's default lower and upper bounds for lens light parameters.
+    - ``uniform_prior``: *(Optional)* Adjust ``dolphin``'s default lower and upper bounds for lens light parameters.
 
       - Type: ``dictionary``
       - Example:

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -276,7 +276,7 @@ Source Light Options
            gaussian_prior:
              0: [[beta, 0.15, 0.05]]
 
-    - ``uniform_prior``: *(Optional)* Adjust dolphin's default lower and upper bounds for source light parameters.
+    - ``uniform_prior``: *(Optional)* Adjust ``dolphin``'s default lower and upper bounds for source light parameters.
 
       - Type: ``dictionary``
       - Example:

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -135,6 +135,17 @@ Lens Options
            gaussian_prior:
              0: [[gamma, 2.11, 0.03], [theta_E, 1.11, 0.13]]
 
+    - ``uniform_prior``: *(Optional)* Adjust dolphin's default lower and upper bounds for lens parameters.
+
+      - Type: ``dictionary``
+      - Example:
+
+        .. code-block:: yaml
+
+           uniform_prior:
+             0: [[theta_E, 0.2, 1.4]]
+             1: [[gamma_ext, 0.02, 0.8]]
+
     - ``fix``: *(Optional)* Fix specific parameters for the lens model.
 
       - Type: ``dictionary``
@@ -227,6 +238,16 @@ Lens Light Options
              0: 
                [[R_sersic, 0.21, 0.15]]
 
+    - ``uniform_prior``: *(Optional)* Adjust dolphin's default lower and upper bounds for lens light parameters.
+
+      - Type: ``dictionary``
+      - Example:
+
+        .. code-block:: yaml
+
+           uniform_prior:
+             0: [[R_sersic, 0.2, 7.], [n_sersic, 0.5, 4.]]
+
     - ``mge_config``: *(Optional)* Configuration for MGE_SET and MGE_SET_ELLIPSE light profiles. Can be used to set the number of Gaussian components.
 
       - Type: ``dictionary``
@@ -254,6 +275,16 @@ Source Light Options
 
            gaussian_prior:
              0: [[beta, 0.15, 0.05]]
+
+    - ``uniform_prior``: *(Optional)* Adjust dolphin's default lower and upper bounds for source light parameters.
+
+      - Type: ``dictionary``
+      - Example:
+
+        .. code-block:: yaml
+
+           uniform_prior:
+             0: [[R_sersic, 0.2, 7.], [n_sersic, 0.5, 4.]]
 
     - ``shapelet_scale_logarithmic_prior``: Whether to apply a logarithmic prior on the shapelet scale parameter.
 

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -135,7 +135,7 @@ Lens Options
            gaussian_prior:
              0: [[gamma, 2.11, 0.03], [theta_E, 1.11, 0.13]]
 
-    - ``uniform_prior``: *(Optional)* Adjust dolphin's default lower and upper bounds for lens parameters.
+    - ``uniform_prior``: *(Optional)* Adjust ``dolphin``'s default lower and upper bounds for lens parameters.
 
       - Type: ``dictionary``
       - Example:

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1845,7 +1845,8 @@ class ModelConfig(Config):
         return fixed_list
 
     def update_uniform_priors(self, component, lower_dict, upper_dict):
-        """Update the default uniform prior bounds with those provided by the user in the config file.
+        """Update the default uniform prior bounds with those provided by the user in
+        the config file.
 
         :param component: name of the model component for which the uniform
           bounds will be altered

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1845,7 +1845,7 @@ class ModelConfig(Config):
         return fixed_list
 
     def get_uniform_priors(self, component, lower_dict, upper_dict):
-        """Adjust the default uniform prior bounds provided by dolphin.
+        """Update the default uniform prior bounds with those provided by the user in the config file.
 
         :param component: name of the model component for which the uniform
           bounds will be altered

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1485,7 +1485,7 @@ class ModelConfig(Config):
                     "{} not implemented as a lens light" "model!".format(model)
                 )
 
-        lower, upper = self.get_uniform_priors("lens_light", lower, upper)
+        lower, upper = self.update_uniform_priors("lens_light", lower, upper)
 
         fixed = self.fill_in_fixed_from_settings("lens_light", fixed)
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1342,6 +1342,8 @@ class ModelConfig(Config):
             else:
                 raise ValueError("{} not implemented as a lens " "model!".format(model))
 
+        lower, upper = self.get_uniform_priors("lens", lower, upper)
+
         fixed = self.fill_in_fixed_from_settings("lens", fixed)
 
         params = [init, sigma, fixed, lower, upper]
@@ -1483,6 +1485,8 @@ class ModelConfig(Config):
                     "{} not implemented as a lens light" "model!".format(model)
                 )
 
+        lower, upper = self.get_uniform_priors("lens_light", lower, upper)
+
         fixed = self.fill_in_fixed_from_settings("lens_light", fixed)
 
         params = [init, sigma, fixed, lower, upper]
@@ -1590,6 +1594,8 @@ class ModelConfig(Config):
                 raise ValueError(
                     "{} not implemented as a source light" "model!".format(model)
                 )
+
+        lower, upper = self.get_uniform_priors("source_light", lower, upper)
 
         fixed = self.fill_in_fixed_from_settings("source_light", fixed)
 
@@ -1837,6 +1843,39 @@ class ModelConfig(Config):
                             fixed_list[int(index)][key] = value
 
         return fixed_list
+    
+    def get_uniform_priors(self, component, lower_dict, upper_dict):
+        """Adjust the default uniform prior bounds provided by dolphin.
+        
+        :param component: name of the model component for which the uniform
+          bounds will be altered
+        :type component: `str`
+        :param lower_dict: the dictionary which contains the default lower bounds
+          of the specified model component 
+        :type lower_dict: `dict`
+        :param upper_dict: the dictionary which contains the default upper bounds
+          of the specified model component
+        :type upper_dict: `dict`
+        :return: a tuple containing the modified lower and upper parameter bound dictionaries
+        :rtype: `tuple` (`dict`, `dict`)
+        """
+        assert component in ["lens", "lens_light", "source_light"]
+        option_str = component + "_options"
+        new_lower_dict = deepcopy(lower_dict)
+        new_upper_dict = deepcopy(upper_dict)
+
+        try:
+            self.settings[option_str]["uniform_prior"]
+        except (NameError, KeyError):
+            pass
+        else:
+            if self.settings[option_str]["uniform_prior"] is not None:
+                for index, param_dict in self.settings[option_str]["uniform_prior"].items():
+                    for key, lower, upper in param_dict:
+                        new_lower_dict[index][key] = lower
+                        new_upper_dict[index][key] = upper
+
+        return new_lower_dict, new_upper_dict
 
     def get_kwargs_params(self):
         """Create `kwargs_params`.

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1844,7 +1844,7 @@ class ModelConfig(Config):
 
         return fixed_list
 
-    def get_uniform_priors(self, component, lower_dict, upper_dict):
+    def update_uniform_priors(self, component, lower_dict, upper_dict):
         """Update the default uniform prior bounds with those provided by the user in the config file.
 
         :param component: name of the model component for which the uniform

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1595,7 +1595,7 @@ class ModelConfig(Config):
                     "{} not implemented as a source light" "model!".format(model)
                 )
 
-        lower, upper = self.get_uniform_priors("source_light", lower, upper)
+        lower, upper = self.update_uniform_priors("source_light", lower, upper)
 
         fixed = self.fill_in_fixed_from_settings("source_light", fixed)
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1342,7 +1342,7 @@ class ModelConfig(Config):
             else:
                 raise ValueError("{} not implemented as a lens " "model!".format(model))
 
-        lower, upper = self.get_uniform_priors("lens", lower, upper)
+        lower, upper = self.update_uniform_priors("lens", lower, upper)
 
         fixed = self.fill_in_fixed_from_settings("lens", fixed)
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1843,15 +1843,15 @@ class ModelConfig(Config):
                             fixed_list[int(index)][key] = value
 
         return fixed_list
-    
+
     def get_uniform_priors(self, component, lower_dict, upper_dict):
         """Adjust the default uniform prior bounds provided by dolphin.
-        
+
         :param component: name of the model component for which the uniform
           bounds will be altered
         :type component: `str`
         :param lower_dict: the dictionary which contains the default lower bounds
-          of the specified model component 
+          of the specified model component
         :type lower_dict: `dict`
         :param upper_dict: the dictionary which contains the default upper bounds
           of the specified model component
@@ -1870,7 +1870,9 @@ class ModelConfig(Config):
             pass
         else:
             if self.settings[option_str]["uniform_prior"] is not None:
-                for index, param_dict in self.settings[option_str]["uniform_prior"].items():
+                for index, param_dict in self.settings[option_str][
+                    "uniform_prior"
+                ].items():
                     for key, lower, upper in param_dict:
                         new_lower_dict[index][key] = lower
                         new_upper_dict[index][key] = upper

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -1180,7 +1180,7 @@ class TestModelConfig(object):
         config_mge_e.settings["model"]["lens_light"] = ["MGE_SET_ELLIPSE"]
         assert config_mge_e.get_kwargs_likelihood()["check_positive_flux"] is False
 
-    def test_get_uniform_priors(self):
+    def test_update_uniform_priors(self):
         """Test the functionality of
         :meth:`~dolphin.processor.config.ModelConfig.get_uniform_priors`."""
 

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -1182,7 +1182,7 @@ class TestModelConfig(object):
 
     def test_update_uniform_priors(self):
         """Test the functionality of
-        :meth:`~dolphin.processor.config.ModelConfig.get_uniform_priors`."""
+        :meth:`~dolphin.processor.config.ModelConfig.update_uniform_priors`."""
 
         config5 = deepcopy(self.config_5)
         config5.settings["model"]["lens_light"] = ["SIS"]

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -1223,7 +1223,7 @@ class TestModelConfig(object):
             }
         }
 
-        lower, upper = config5.get_uniform_priors(
+        lower, upper = config5.update_uniform_priors(
             "lens_light", lower_default, upper_default
         )
         assert lower == lower_test

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -840,6 +840,19 @@ class TestModelConfig(object):
             "g4": 0.1,
         }
 
+        # Test uniform prior functionality
+        config3 = deepcopy(self.config_3)
+        config3.settings["lens_options"]["uniform_prior"] = {
+            0: [["theta_E", 0.2, 1.3]],
+            1: [["gamma_ext", 0.04, 0.1]]
+        }
+        params = config3.get_lens_model_params()
+
+        assert params[3][0]["theta_E"] == .2
+        assert params[3][1]["gamma_ext"] == .04
+        assert params[4][0]["theta_E"] == 1.3
+        assert params[4][1]["gamma_ext"] == .1
+
     def test_get_lens_light_model_params(self):
         """Test `get_lens_light_model_params` method."""
         config = deepcopy(self.config_5)
@@ -894,6 +907,18 @@ class TestModelConfig(object):
         assert params[3] == [{"amp": -100.0}]
         assert params[4] == [{"amp": 100.0}]
 
+        # Test uniform prior functionality
+        config5 = deepcopy(self.config_5)
+        config5.settings["lens_light_options"]["uniform_prior"] = {
+            0: [["R_sersic", 0.345, 6.], ["e1", 0., .723]]
+        }
+        params = config5.get_lens_light_model_params()
+
+        assert params[3][0]["R_sersic"] == 0.345
+        assert params[3][0]["e1"] == 0.
+        assert params[4][0]["R_sersic"] == 6.
+        assert params[4][0]["e1"] == .723
+
     def test_get_source_light_model_params(self):
         """Test `get_source_light_model_params` method."""
         config = deepcopy(self.config_1)
@@ -909,6 +934,18 @@ class TestModelConfig(object):
         config3.settings["source_light_options"]["n_max"] = 2
         config3.get_source_light_model_params()
         assert config3.settings["source_light_options"]["n_max"] == [2, 2]
+
+        # Test uniform prior functionality
+        config3 = deepcopy(self.config_3)
+        config3.settings["source_light_options"]["uniform_prior"] = {
+            0: [["R_sersic", 0.345, 6.], ["e1", 0., .723]]
+        }
+        params = config3.get_source_light_model_params()
+
+        assert params[3][0]["R_sersic"] == 0.345
+        assert params[3][0]["e1"] == 0.
+        assert params[4][0]["R_sersic"] == 6.
+        assert params[4][0]["e1"] == .723
 
     def test_get_special_params(self):
         """Test `get_special_params` method."""
@@ -1142,3 +1179,53 @@ class TestModelConfig(object):
         config_mge_e = deepcopy(self.config_1)
         config_mge_e.settings["model"]["lens_light"] = ["MGE_SET_ELLIPSE"]
         assert config_mge_e.get_kwargs_likelihood()["check_positive_flux"] is False
+
+    def test_get_uniform_priors(self):
+        """Test the functionality of
+          :meth:`~dolphin.processor.config.ModelConfig.get_uniform_priors`."""
+        
+        config5 = deepcopy(self.config_5)
+        config5.settings["model"]["lens_light"] = ["SIS"]
+        config5.settings["lens_light_options"]["uniform_prior"] = {
+            0: [["R_sersic", 0.5, 6.]]
+        }
+        lower_default = {0: 
+                         {
+                            "n_sersic": 0.5, 
+                            "R_sersic": 0.1, 
+                            "center_x": 0.04 - 0.5, 
+                            "center_y": -0.04 - 0.5
+                        }                   
+                    }
+        upper_default = {0: 
+                         {
+                            "n_sersic": 8., 
+                            "R_sersic": 5., 
+                            "center_x": 0.04 + 0.5, 
+                            "center_y": -0.04 + 0.5
+                         }
+        }
+
+        lower_test = {0: 
+                         {
+                            "n_sersic": 0.5, 
+                            "R_sersic": 0.5, 
+                            "center_x": 0.04 - 0.5, 
+                            "center_y": -0.04 - 0.5
+                        }                   
+                    }
+        upper_test = {0: 
+                         {
+                            "n_sersic": 8., 
+                            "R_sersic": 6., 
+                            "center_x": 0.04 + 0.5, 
+                            "center_y": -0.04 + 0.5
+                         }
+        }
+            
+        lower, upper = config5.get_uniform_priors("lens_light", lower_default, upper_default)
+        assert lower == lower_test
+        assert upper == upper_test
+
+        with pytest.raises(AssertionError):
+            self.config_3.get_uniform_priors("invalid", lower_default, upper_default)

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -1230,4 +1230,4 @@ class TestModelConfig(object):
         assert upper == upper_test
 
         with pytest.raises(AssertionError):
-            self.config_3.get_uniform_priors("invalid", lower_default, upper_default)
+            self.config_3.update_uniform_priors("invalid", lower_default, upper_default)

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -844,14 +844,14 @@ class TestModelConfig(object):
         config3 = deepcopy(self.config_3)
         config3.settings["lens_options"]["uniform_prior"] = {
             0: [["theta_E", 0.2, 1.3]],
-            1: [["gamma_ext", 0.04, 0.1]]
+            1: [["gamma_ext", 0.04, 0.1]],
         }
         params = config3.get_lens_model_params()
 
-        assert params[3][0]["theta_E"] == .2
-        assert params[3][1]["gamma_ext"] == .04
+        assert params[3][0]["theta_E"] == 0.2
+        assert params[3][1]["gamma_ext"] == 0.04
         assert params[4][0]["theta_E"] == 1.3
-        assert params[4][1]["gamma_ext"] == .1
+        assert params[4][1]["gamma_ext"] == 0.1
 
     def test_get_lens_light_model_params(self):
         """Test `get_lens_light_model_params` method."""
@@ -910,14 +910,14 @@ class TestModelConfig(object):
         # Test uniform prior functionality
         config5 = deepcopy(self.config_5)
         config5.settings["lens_light_options"]["uniform_prior"] = {
-            0: [["R_sersic", 0.345, 6.], ["e1", 0., .723]]
+            0: [["R_sersic", 0.345, 6.0], ["e1", 0.0, 0.723]]
         }
         params = config5.get_lens_light_model_params()
 
         assert params[3][0]["R_sersic"] == 0.345
-        assert params[3][0]["e1"] == 0.
-        assert params[4][0]["R_sersic"] == 6.
-        assert params[4][0]["e1"] == .723
+        assert params[3][0]["e1"] == 0.0
+        assert params[4][0]["R_sersic"] == 6.0
+        assert params[4][0]["e1"] == 0.723
 
     def test_get_source_light_model_params(self):
         """Test `get_source_light_model_params` method."""
@@ -938,14 +938,14 @@ class TestModelConfig(object):
         # Test uniform prior functionality
         config3 = deepcopy(self.config_3)
         config3.settings["source_light_options"]["uniform_prior"] = {
-            0: [["R_sersic", 0.345, 6.], ["e1", 0., .723]]
+            0: [["R_sersic", 0.345, 6.0], ["e1", 0.0, 0.723]]
         }
         params = config3.get_source_light_model_params()
 
         assert params[3][0]["R_sersic"] == 0.345
-        assert params[3][0]["e1"] == 0.
-        assert params[4][0]["R_sersic"] == 6.
-        assert params[4][0]["e1"] == .723
+        assert params[3][0]["e1"] == 0.0
+        assert params[4][0]["R_sersic"] == 6.0
+        assert params[4][0]["e1"] == 0.723
 
     def test_get_special_params(self):
         """Test `get_special_params` method."""
@@ -1182,48 +1182,50 @@ class TestModelConfig(object):
 
     def test_get_uniform_priors(self):
         """Test the functionality of
-          :meth:`~dolphin.processor.config.ModelConfig.get_uniform_priors`."""
-        
+        :meth:`~dolphin.processor.config.ModelConfig.get_uniform_priors`."""
+
         config5 = deepcopy(self.config_5)
         config5.settings["model"]["lens_light"] = ["SIS"]
         config5.settings["lens_light_options"]["uniform_prior"] = {
-            0: [["R_sersic", 0.5, 6.]]
+            0: [["R_sersic", 0.5, 6.0]]
         }
-        lower_default = {0: 
-                         {
-                            "n_sersic": 0.5, 
-                            "R_sersic": 0.1, 
-                            "center_x": 0.04 - 0.5, 
-                            "center_y": -0.04 - 0.5
-                        }                   
-                    }
-        upper_default = {0: 
-                         {
-                            "n_sersic": 8., 
-                            "R_sersic": 5., 
-                            "center_x": 0.04 + 0.5, 
-                            "center_y": -0.04 + 0.5
-                         }
+        lower_default = {
+            0: {
+                "n_sersic": 0.5,
+                "R_sersic": 0.1,
+                "center_x": 0.04 - 0.5,
+                "center_y": -0.04 - 0.5,
+            }
+        }
+        upper_default = {
+            0: {
+                "n_sersic": 8.0,
+                "R_sersic": 5.0,
+                "center_x": 0.04 + 0.5,
+                "center_y": -0.04 + 0.5,
+            }
         }
 
-        lower_test = {0: 
-                         {
-                            "n_sersic": 0.5, 
-                            "R_sersic": 0.5, 
-                            "center_x": 0.04 - 0.5, 
-                            "center_y": -0.04 - 0.5
-                        }                   
-                    }
-        upper_test = {0: 
-                         {
-                            "n_sersic": 8., 
-                            "R_sersic": 6., 
-                            "center_x": 0.04 + 0.5, 
-                            "center_y": -0.04 + 0.5
-                         }
+        lower_test = {
+            0: {
+                "n_sersic": 0.5,
+                "R_sersic": 0.5,
+                "center_x": 0.04 - 0.5,
+                "center_y": -0.04 - 0.5,
+            }
         }
-            
-        lower, upper = config5.get_uniform_priors("lens_light", lower_default, upper_default)
+        upper_test = {
+            0: {
+                "n_sersic": 8.0,
+                "R_sersic": 6.0,
+                "center_x": 0.04 + 0.5,
+                "center_y": -0.04 + 0.5,
+            }
+        }
+
+        lower, upper = config5.get_uniform_priors(
+            "lens_light", lower_default, upper_default
+        )
         assert lower == lower_test
         assert upper == upper_test
 


### PR DESCRIPTION
This PR adds support for modification of Dolphin's default lower and upper bounds via the `.yaml` configuration file. New tests and documentation have been included accordingly.