### PR TITLE
Fix indexing of uniform priors for post-analyses

### DIFF
--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1874,6 +1874,7 @@ class ModelConfig(Config):
                 for index, param_dict in self.settings[option_str][
                     "uniform_prior"
                 ].items():
+                    index = int(index)
                     for key, lower, upper in param_dict:
                         new_lower_dict[index][key] = lower
                         new_upper_dict[index][key] = upper


### PR DESCRIPTION
This is a minor PR which fixes uniform prior indexing during post-analyses. This issue stems from the fact that dolphin's model settings return the integer indices of `uniform_prior` as type `str`. For example, from `output.model_settings`:
`{
...,
'uniform_prior': {'0': [['theta_E', ....]]},
...
}`

Subsequently, `output.get_param_class` fails during `config.get_kwargs_params()` because the referenced index is a `str`, not an `int`. In this PR, I simply convert the model index directly to an integer.