### PR TITLE
Minor usage improvements

### DIFF
--- a/dolphin/processor/core.py
+++ b/dolphin/processor/core.py
@@ -52,7 +52,9 @@ class Processor(object):
         :type log: `bool`
         :param mpi: enable MPI for parallel processing
         :type mpi: `bool`
-        :param recipe_name: recipe for pre-sampling optimization. Supported: 'galaxy-quasar', 'galaxy-galaxy', 'skip'. 'skip' will skip pre-sampling optimization and directly sample the full model. See `Recipe` class for details.
+        :param recipe_name: recipe for pre-sampling optimization. Supported: 'galaxy-quasar', 'galaxy-galaxy', 'custom', 'skip'.
+            'custom' will use the fitting_kwargs_list directly from the yaml settings for pre-sampling optimization.
+            'skip' will skip pre-sampling optimization and directly sample the full model. See `Recipe` class for details.
         :type recipe_name: `str`
         :param thread_count: number of threads to use if multiprocess is enabled
         :type thread_count: `int`

--- a/dolphin/processor/files.py
+++ b/dolphin/processor/files.py
@@ -11,6 +11,7 @@ import h5py
 import gdown
 from warnings import warn
 
+
 class FileSystem(object):
     """This class contains methods to handle the file system, directory paths, and
     standard IO operations."""

--- a/dolphin/processor/files.py
+++ b/dolphin/processor/files.py
@@ -9,7 +9,7 @@ import json
 import numpy as np
 import h5py
 import gdown
-
+from warnings import warn
 
 class FileSystem(object):
     """This class contains methods to handle the file system, directory paths, and
@@ -293,9 +293,9 @@ class FileSystem(object):
                             "log_l", data=np.array(single_output[6]["log_l"])
                         )
                 else:
-                    raise ValueError(
-                        f"Fitting type {single_output[0]} not recognized for "
-                        "saving output!"
+                    warn(
+                        f"Fitting type {single_output[0]} not recognized for saving output!"
+                        "Saved output will not be available for this fitting type."
                     )
 
     def load_output(self, lens_name, model_id, file_type="h5"):

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -90,7 +90,9 @@ class Recipe(object):
             try:
                 self._config.settings["fitting_kwargs_list"]
             except (KeyError, NameError):
-                raise KeyError("custom recipe_name requires fitting_kwargs_list key in yaml settings")
+                raise KeyError(
+                    "custom recipe_name requires fitting_kwargs_list key in yaml settings"
+                )
             else:
                 if self._config.settings["fitting_kwargs_list"] is not None:
                     fitting_kwargs_list += self._config.settings["fitting_kwargs_list"]

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -79,24 +79,25 @@ class Recipe(object):
 
         :param kwargs_data_joint: `kwargs_data_joint` dictionary for multiple bands
         :type kwargs_data_joint: `dict` or `None`
-        :param recipe_name: recipe name, 'galaxy-quasar', 'galaxy-galaxy', or 'skip'
+        :param recipe_name: recipe name, 'galaxy-quasar', 'galaxy-galaxy', 'custom', or 'skip'
         :type recipe_name: `str`
         :return: fitting kwargs list
         :rtype: `list`
         """
         fitting_kwargs_list = []
 
-        if recipe_name == "galaxy-quasar":
+        if recipe_name == "custom":
             try:
-                # if this key exists then return it
                 self._config.settings["fitting_kwargs_list"]
             except (KeyError, NameError):
-                fitting_kwargs_list += self.get_galaxy_quasar_recipe()
+                raise KeyError("custom recipe_name requires fitting_kwargs_list key in yaml settings")
             else:
                 if self._config.settings["fitting_kwargs_list"] is not None:
                     fitting_kwargs_list += self._config.settings["fitting_kwargs_list"]
                 else:
-                    fitting_kwargs_list += self.get_galaxy_quasar_recipe()
+                    pass
+        elif recipe_name == "galaxy-quasar":
+            fitting_kwargs_list += self.get_galaxy_quasar_recipe()
         elif recipe_name == "galaxy-galaxy":
             if kwargs_data_joint is None:
                 raise ValueError(

--- a/test/test_processor/test_files.py
+++ b/test/test_processor/test_files.py
@@ -191,7 +191,7 @@ class TestFileSystem(object):
         for key in save_nautilus[6]:
             assert np.all(out_nautilus[6][key] == save_nautilus[6][key])
 
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning):
             save_dict["fit_output"].append(
                 [
                     "INVALID",

--- a/test/test_processor/test_recipe.py
+++ b/test/test_processor/test_recipe.py
@@ -59,11 +59,12 @@ class TestRecipe(object):
 
         config.settings["fitting_kwargs_list"] = [{}, {}]
         recipe = Recipe(config)
-        assert recipe.get_recipe()[:2] == [{}, {}]
+        assert recipe.get_recipe(recipe_name='custom')[:2] == [{}, {}]
 
         config.settings["fitting_kwargs_list"] = None
         recipe = Recipe(config)
-        assert isinstance(recipe.get_recipe(), list)
+        assert isinstance(recipe.get_recipe(recipe_name='custom'), list)
+        assert recipe.get_recipe(recipe_name="custom")[0][0] == "emcee"
 
         # check requirement to pass `kwargs_data_joint`
         with pytest.raises(ValueError):

--- a/test/test_processor/test_recipe.py
+++ b/test/test_processor/test_recipe.py
@@ -59,11 +59,11 @@ class TestRecipe(object):
 
         config.settings["fitting_kwargs_list"] = [{}, {}]
         recipe = Recipe(config)
-        assert recipe.get_recipe(recipe_name='custom')[:2] == [{}, {}]
+        assert recipe.get_recipe(recipe_name="custom")[:2] == [{}, {}]
 
         config.settings["fitting_kwargs_list"] = None
         recipe = Recipe(config)
-        assert isinstance(recipe.get_recipe(recipe_name='custom'), list)
+        assert isinstance(recipe.get_recipe(recipe_name="custom"), list)
         assert recipe.get_recipe(recipe_name="custom")[0][0] == "emcee"
 
         # check requirement to pass `kwargs_data_joint`

--- a/test/test_processor/test_recipe.py
+++ b/test/test_processor/test_recipe.py
@@ -66,6 +66,13 @@ class TestRecipe(object):
         assert isinstance(recipe.get_recipe(recipe_name="custom"), list)
         assert recipe.get_recipe(recipe_name="custom")[0][0] == "emcee"
 
+        # Check that an error is raised if a custom recipe is demanded
+        # without supplying the fitting_kwargs_list
+        with pytest.raises(KeyError):
+            del config.settings["fitting_kwargs_list"]
+            recipe = Recipe(config)
+            recipe.get_recipe(recipe_name="custom")
+
         # check requirement to pass `kwargs_data_joint`
         with pytest.raises(ValueError):
             recipe.get_recipe(recipe_name="galaxy-galaxy")


### PR DESCRIPTION
1. dolphin already enables the user to supply a custom pre-sampling optimization recipe by specifying `recipe_name="galaxy-quasar"` and including a `fitting_kwargs_list` field in the yaml settings. This PR makes this feature clearer and more intuitive to use by requiring `recipe_name='custom'` instead.
2. When saving outputs of FittingSequence to h5, unrecognized fitting types result in an error. This PR changes this behavior so that a warning is raised instead. When supplying a custom recipe, this change allows the user to use fitting types that do not require saving or do not yet support saving, like JAXtronomy's gradient descent.