### PR TITLE
guess_params usage enhancement

### DIFF
--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -106,7 +106,8 @@ Lens Options
 
   - Suboptions:
 
-    - ``centroid_init``: Initial guess for the lens centroid.
+    - ``centroid_init``: Initial guess for the lens centroid. This will apply to all lens model components.
+    For more fine-tuned control of individual lens model positions, see ``initial_guesses`` below.
 
       - Type: ``list of floats``
       - Example:
@@ -115,7 +116,8 @@ Lens Options
 
            centroid_init: [0.04, -0.04]
     
-    - ``centroid_bound``: Half of the box width to constrain the deflector's centroid.
+    - ``centroid_bound``: Half of the box width to constrain the deflector's centroid. This will apply to all lens model components.
+    For more fine-tuned control of the bounds for individual lens model positions, see ``uniform_prior`` below.
 
       - Type: ``float``
       - Default: ``0.5``
@@ -124,6 +126,21 @@ Lens Options
         .. code-block:: yaml
 
            centroid_bound: 0.5
+
+    - ``initial_guesses``: *(Optional)* Adjust ``dolphin``'s default initial lens parameters.
+
+      - Type: ``dictionary``
+      - Example:
+
+        .. code-block:: yaml
+
+           initial_guesses:
+             0:
+               theta_E: 1.3
+               gamma: 2.0
+             1:
+               e1: 0.3
+               e2: -0.1
 
     - ``gaussian_prior``: *(Optional)* Gaussian priors for lens parameters.
 
@@ -143,7 +160,7 @@ Lens Options
         .. code-block:: yaml
 
            uniform_prior:
-             0: [[theta_E, 0.2, 1.4]]
+             0: [[theta_E, 0.2, 1.4], [center_x, 0.5, 0.9]]
              1: [[gamma_ext, 0.02, 0.8]]
 
     - ``fix``: *(Optional)* Fix specific parameters for the lens model.
@@ -218,6 +235,21 @@ Lens Light Options
 
   - Suboptions:
 
+    - ``initial_guesses``: *(Optional)* Adjust ``dolphin``'s default initial lens light parameters.
+
+      - Type: ``dictionary``
+      - Example:
+
+        .. code-block:: yaml
+
+           initial_guesses:
+             0:
+               R_sersic: 2.3
+               n_sersic: 1
+             1:
+               R_sersic: 0.3
+               n_sersic: 4
+
     - ``fix``: Fix specific parameters for the lens light profile.
 
       - Type: ``dictionary``
@@ -265,6 +297,21 @@ Source Light Options
 - ``source_light_options``: *(Optional)* Additional options for the source light model.
 
   - Suboptions:
+
+    - ``initial_guesses``: *(Optional)* Adjust ``dolphin``'s default initial source light parameters.
+
+      - Type: ``dictionary``
+      - Example:
+
+        .. code-block:: yaml
+
+           initial_guesses:
+             0:
+               R_sersic: 2.3
+               n_sersic: 1
+             1:
+               R_sersic: 0.3
+               n_sersic: 4
 
     - ``gaussian_prior``: Gaussian priors for source light parameters.
 
@@ -543,30 +590,6 @@ Special Options
 
         p \rightarrow p_{\mathrm{scaled}} =
         f_p \, p^{\alpha_p}
-
-Guess Parameters
-----------------
-
-- ``guess_params``: *(Optional)* Initial guess parameter values for component models. This is commonly used to 
-  overwrite default initial configurations and center the bounds of the PSO optimization process.
-
-  - Suboptions:
-
-    - ``lens``: Guess parameters for lens models.
-    - ``lens_light``: Guess parameters for lens light models.
-    - ``source_light``: Guess parameters for source light models.
-    - To configure initial parameters for point source models, see Point Source Options.
-
-    - Example:
-
-      .. code-block:: yaml
-
-         guess_params:
-           lens:
-             0:
-               theta_E: 1.2
-               e1: 0.05
-               e2: -0.05
 
 Numeric Options
 ---------------
@@ -850,6 +873,7 @@ Fitting Options
                block_center_neighbour: 0.0
 
 - ``fitting_kwargs_list``: *(Optional)* User-provided list of fitting sequences to bypass the automated recipes in dolphin.
+In order to use this list, the ``Processor.swim()`` method must be called with ``recipe_name="custom"``.
 
   - Type: ``list``
   - Example:

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -554,8 +554,8 @@ Guess Parameters
 
     - ``lens``: Guess parameters for lens models.
     - ``lens_light``: Guess parameters for lens light models.
-    - ``source``: Guess parameters for source light models.
-    - ``ps``: Guess parameters for point source models.
+    - ``source_light``: Guess parameters for source light models.
+    - To configure initial parameters for point source models, Point Source Options.
 
     - Example:
 

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -555,7 +555,7 @@ Guess Parameters
     - ``lens``: Guess parameters for lens models.
     - ``lens_light``: Guess parameters for lens light models.
     - ``source_light``: Guess parameters for source light models.
-    - To configure initial parameters for point source models, Point Source Options.
+    - To configure initial parameters for point source models, see Point Source Options.
 
     - Example:
 

--- a/CONFIG_OPTIONS.rst
+++ b/CONFIG_OPTIONS.rst
@@ -107,7 +107,7 @@ Lens Options
   - Suboptions:
 
     - ``centroid_init``: Initial guess for the lens centroid. This will apply to all lens model components.
-    For more fine-tuned control of individual lens model positions, see ``initial_guesses`` below.
+      For more fine-tuned control of individual lens model positions, see ``initial_guesses`` below.
 
       - Type: ``list of floats``
       - Example:
@@ -117,7 +117,7 @@ Lens Options
            centroid_init: [0.04, -0.04]
     
     - ``centroid_bound``: Half of the box width to constrain the deflector's centroid. This will apply to all lens model components.
-    For more fine-tuned control of the bounds for individual lens model positions, see ``uniform_prior`` below.
+      For more fine-tuned control of the bounds for individual lens model positions, see ``uniform_prior`` below.
 
       - Type: ``float``
       - Default: ``0.5``

--- a/dolphin/ai/modeler.py
+++ b/dolphin/ai/modeler.py
@@ -214,9 +214,10 @@ class Modeler(AI):
             "centroid_bound": satellite_bound,
         }
 
-        # Set guess params
+        # Set initial guesses
         theta_E_init = self.get_theta_E_init(semantic_segmentation, coordinate_system)
-        config["guess_params"] = {"lens": {0: {"theta_E": float(theta_E_init)}}}
+        config["lens_options"]["initial_guesses"] = {}
+        config["lens_options"]["initial_guesses"][0] = {"theta_E": float(theta_E_init)}
 
         # Set numeric options
         config["numeric_options"] = {"supersampling_factor": supersampling_factor}

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1948,14 +1948,14 @@ class ModelConfig(Config):
                 if key in fixed_dict_list[model_index].keys():
                     continue
 
-                error_string = f"\n{component} model with index {model_index} contains parameter {key} with initial value {value}"
+                error_string = f"\n{component} model component at index {model_index} contains parameter {key} with initial value {value}"
 
                 if key in lower_dict_list[model_index].keys():
                     lower_bound = lower_dict_list[model_index][key]
                     if value < lower_bound:
                         warn(
                             error_string
-                            + f" which is less than the lower bound {lower_bound}"
+                            + f", which is less than the lower bound {lower_bound}!"
                         )
 
                 if key in upper_dict_list[model_index].keys():
@@ -1963,7 +1963,7 @@ class ModelConfig(Config):
                     if value > upper_bound:
                         warn(
                             error_string
-                            + f" which is greater than the upper bound {upper_bound}"
+                            + f", which is greater than the upper bound {upper_bound}!"
                         )
 
     def get_kwargs_params(self):

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1938,6 +1938,8 @@ class ModelConfig(Config):
         :param upper_dict_list: the list of dictionaries which contains the upper bounds
           of the specified model component
         :type upper_dict_list: `list` of `dict`
+        :return: None
+        :rtype: `None`
         """
         assert component in ["lens", "lens_light", "source_light"]
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -6,6 +6,7 @@ __author__ = "ajshajib"
 from ruamel.yaml import YAML
 import numpy as np
 from copy import deepcopy
+from warnings import warn
 
 from lenstronomy.Util.param_util import ellipticity2phi_q
 import lenstronomy.Util.util as util
@@ -115,6 +116,16 @@ class ModelConfig(Config):
                     self.settings[f"{opt}_option"]
                 )
                 del self.settings[f"{opt}_option"]
+
+        self.guess_params = {}
+        for component in ["lens", "source_light", "lens_light", "ps"]:
+            try:
+                self.guess_params[component] = deepcopy(
+                    self.settings["guess_params"][component]
+                )
+            except (NameError, KeyError):
+                self.guess_params[component] = None
+
 
     @property
     def lens_name(self):
@@ -1203,7 +1214,7 @@ class ModelConfig(Config):
                 center_x = self.deflector_center_ra
                 center_y = self.deflector_center_dec
                 try:
-                    theta_E_init = self.settings["guess_params"]["lens"][0]["theta_E"]
+                    theta_E_init = self.settings["guess_params"]["lens"][i]["theta_E"]
                 except (NameError, KeyError):
                     theta_E_init = 1.0
 
@@ -1342,9 +1353,10 @@ class ModelConfig(Config):
             else:
                 raise ValueError("{} not implemented as a lens " "model!".format(model))
 
+        init = self.update_initial_guesses("lens", init)
         lower, upper = self.update_uniform_priors("lens", lower, upper)
-
         fixed = self.fill_in_fixed_from_settings("lens", fixed)
+        self.check_init_params_in_bounds("lens", init, fixed, lower, upper)
 
         params = [init, sigma, fixed, lower, upper]
         return params
@@ -1485,9 +1497,10 @@ class ModelConfig(Config):
                     "{} not implemented as a lens light" "model!".format(model)
                 )
 
+        init = self.update_initial_guesses("lens_light", init)
         lower, upper = self.update_uniform_priors("lens_light", lower, upper)
-
         fixed = self.fill_in_fixed_from_settings("lens_light", fixed)
+        self.check_init_params_in_bounds("lens_light", init, fixed, lower, upper)
 
         params = [init, sigma, fixed, lower, upper]
         return params
@@ -1595,9 +1608,10 @@ class ModelConfig(Config):
                     "{} not implemented as a source light" "model!".format(model)
                 )
 
+        init = self.update_initial_guesses("source_light", init)
         lower, upper = self.update_uniform_priors("source_light", lower, upper)
-
         fixed = self.fill_in_fixed_from_settings("source_light", fixed)
+        self.check_init_params_in_bounds("source_light", init, fixed, lower, upper)
 
         params = [init, sigma, fixed, lower, upper]
         return params
@@ -1844,26 +1858,49 @@ class ModelConfig(Config):
 
         return fixed_list
 
-    def update_uniform_priors(self, component, lower_dict, upper_dict):
+    
+    def update_initial_guesses(self, component, init_dict_list):
+        """Update the default initial parameter values with those provided by the user in
+        the config file as guess_params.
+
+        :param component: name of the model component for which the initial parameter values
+          will be updated
+        :type component: `str`
+        :param init_dict_list: the list of dictionaries containing the default initial parameter values
+          of the specified model component
+        :type init_dict_list: `list` of `dict`
+        :return: a modified list of dictionaries containing the updated initial parameter values
+        :rtype: `list` of `dict`
+        """
+        assert component in ["lens", "lens_light", "source_light"]
+        new_init_dict_list = deepcopy(init_dict_list)
+
+        if self.guess_params[component] is not None:
+            for model_index in self.guess_params[component].keys():
+                new_init_dict_list[model_index].update(self.guess_params[component][model_index])
+
+        return new_init_dict_list
+
+    def update_uniform_priors(self, component, lower_dict_list, upper_dict_list):
         """Update the default uniform prior bounds with those provided by the user in
         the config file.
 
         :param component: name of the model component for which the uniform
           bounds will be altered
         :type component: `str`
-        :param lower_dict: the dictionary which contains the default lower bounds
+        :param lower_dict_list: the list of dictionaries which contains the default lower bounds
           of the specified model component
-        :type lower_dict: `dict`
-        :param upper_dict: the dictionary which contains the default upper bounds
+        :type lower_dict_list: `list` of `dict`
+        :param upper_dict_list: the list of dictionaries which contains the default upper bounds
           of the specified model component
-        :type upper_dict: `dict`
-        :return: a tuple containing the modified lower and upper parameter bound dictionaries
-        :rtype: `tuple` (`dict`, `dict`)
+        :type upper_dict_list: `list` of `dict`
+        :return: a tuple containing the modified lower and upper parameter bound dictionary lists
+        :rtype: `tuple` (`list` of `dict`, `list` of `dict`)
         """
         assert component in ["lens", "lens_light", "source_light"]
         option_str = component + "_options"
-        new_lower_dict = deepcopy(lower_dict)
-        new_upper_dict = deepcopy(upper_dict)
+        new_lower_dict_list = deepcopy(lower_dict_list)
+        new_upper_dict_list = deepcopy(upper_dict_list)
 
         try:
             self.settings[option_str]["uniform_prior"]
@@ -1876,10 +1913,51 @@ class ModelConfig(Config):
                 ].items():
                     index = int(index)
                     for key, lower, upper in param_dict:
-                        new_lower_dict[index][key] = lower
-                        new_upper_dict[index][key] = upper
+                        new_lower_dict_list[index][key] = lower
+                        new_upper_dict_list[index][key] = upper
 
-        return new_lower_dict, new_upper_dict
+        return new_lower_dict_list, new_upper_dict_list
+
+    @staticmethod
+    def check_init_params_in_bounds(component, init_dict_list, fixed_dict_list, lower_dict_list, upper_dict_list):
+        """Checks that initial parameters are within the specified bounds. If not, a warning
+        is raised for each parameter that is not within bounds. This check is only performed on
+        parameters that are not fixed.
+
+        :param component: name of the model component for which the check is done
+        :type component: `str`
+        :param init_dict_list: the list of dictionaries containing the initial parameter values
+          of the specified model component
+        :type init_dict_list: `list` of `dict`
+        :param fixed_list: list of dictionaries containing fixed params
+        :type fixed_list: `list` of `dict`
+        :param lower_dict_list: the list of dictionaries which contains the lower bounds
+          of the specified model component
+        :type lower_dict_list: `list` of `dict`
+        :param upper_dict_list: the list of dictionaries which contains the upper bounds
+          of the specified model component
+        :type upper_dict_list: `list` of `dict`
+        """
+        assert component in ["lens", "lens_light", "source_light"]
+
+        for model_index in range(len(init_dict_list)):
+            for key, value in init_dict_list[model_index].items():
+
+                # Skip the check if the parameter is fixed
+                if key in fixed_dict_list[model_index].keys():
+                    continue
+
+                error_string = f"\n{component} model with index {model_index} contains parameter {key} with initial value {value}"
+
+                if key in lower_dict_list[model_index].keys():
+                    lower_bound = lower_dict_list[model_index][key]
+                    if value < lower_bound:
+                        warn(error_string + f" which is less than the lower bound {lower_bound}")
+
+                if key in upper_dict_list[model_index].keys():
+                    upper_bound = upper_dict_list[model_index][key]
+                    if value > upper_bound:
+                        warn(error_string + f" which is greater than the upper bound {upper_bound}")
 
     def get_kwargs_params(self):
         """Create `kwargs_params`.

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -126,7 +126,6 @@ class ModelConfig(Config):
             except (NameError, KeyError):
                 self.guess_params[component] = None
 
-
     @property
     def lens_name(self):
         """The name of the lens system.
@@ -1858,10 +1857,9 @@ class ModelConfig(Config):
 
         return fixed_list
 
-    
     def update_initial_guesses(self, component, init_dict_list):
-        """Update the default initial parameter values with those provided by the user in
-        the config file as guess_params.
+        """Update the default initial parameter values with those provided by the user
+        in the config file as guess_params.
 
         :param component: name of the model component for which the initial parameter values
           will be updated
@@ -1877,7 +1875,9 @@ class ModelConfig(Config):
 
         if self.guess_params[component] is not None:
             for model_index in self.guess_params[component].keys():
-                new_init_dict_list[model_index].update(self.guess_params[component][model_index])
+                new_init_dict_list[model_index].update(
+                    self.guess_params[component][model_index]
+                )
 
         return new_init_dict_list
 
@@ -1919,10 +1919,12 @@ class ModelConfig(Config):
         return new_lower_dict_list, new_upper_dict_list
 
     @staticmethod
-    def check_init_params_in_bounds(component, init_dict_list, fixed_dict_list, lower_dict_list, upper_dict_list):
-        """Checks that initial parameters are within the specified bounds. If not, a warning
-        is raised for each parameter that is not within bounds. This check is only performed on
-        parameters that are not fixed.
+    def check_init_params_in_bounds(
+        component, init_dict_list, fixed_dict_list, lower_dict_list, upper_dict_list
+    ):
+        """Checks that initial parameters are within the specified bounds. If not, a
+        warning is raised for each parameter that is not within bounds. This check is
+        only performed on parameters that are not fixed.
 
         :param component: name of the model component for which the check is done
         :type component: `str`
@@ -1952,12 +1954,18 @@ class ModelConfig(Config):
                 if key in lower_dict_list[model_index].keys():
                     lower_bound = lower_dict_list[model_index][key]
                     if value < lower_bound:
-                        warn(error_string + f" which is less than the lower bound {lower_bound}")
+                        warn(
+                            error_string
+                            + f" which is less than the lower bound {lower_bound}"
+                        )
 
                 if key in upper_dict_list[model_index].keys():
                     upper_bound = upper_dict_list[model_index][key]
                     if value > upper_bound:
-                        warn(error_string + f" which is greater than the upper bound {upper_bound}")
+                        warn(
+                            error_string
+                            + f" which is greater than the upper bound {upper_bound}"
+                        )
 
     def get_kwargs_params(self):
         """Create `kwargs_params`.

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -127,10 +127,12 @@ class ModelConfig(Config):
                 self.guess_params[component] = None
 
         if (
-            "ps" in self.settings["guess_params"].keys() or
-            "point_source" in self.settings["guess_params"].keys()
+            "ps" in self.settings["guess_params"].keys()
+            or "point_source" in self.settings["guess_params"].keys()
         ):
-            raise ValueError("Initial point source parameter values should be provided in point_source_options instead of guess_params")
+            raise ValueError(
+                "Initial point source parameter values should be provided in point_source_options instead of guess_params"
+            )
 
     @property
     def lens_name(self):

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1865,16 +1865,18 @@ class ModelConfig(Config):
         """
         assert component in ["lens", "lens_light", "source_light", "point_source"]
 
-        if "initial_guesses" in self.settings[component + "_options"].keys():
-            new_init_dict_list = deepcopy(init_dict_list)
-            for model_index, init_dict in self.settings[component + "_options"][
-                "initial_guesses"
-            ].items():
-                new_init_dict_list[int(model_index)].update(init_dict)
+        options_string = component + "_options"
+        if options_string in self.settings.keys():
+            if "initial_guesses" in self.settings[options_string].keys():
+                new_init_dict_list = deepcopy(init_dict_list)
+                for model_index, init_dict in self.settings[options_string][
+                    "initial_guesses"
+                ].items():
+                    new_init_dict_list[int(model_index)].update(init_dict)
 
-            return new_init_dict_list
-        else:
-            return init_dict_list
+                return new_init_dict_list
+
+        return init_dict_list
 
     def update_uniform_priors(self, component, lower_dict_list, upper_dict_list):
         """Update the default uniform prior bounds with those provided by the user in

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -117,7 +117,6 @@ class ModelConfig(Config):
                 )
                 del self.settings[f"{opt}_option"]
 
-
     @property
     def lens_name(self):
         """The name of the lens system.
@@ -1205,7 +1204,9 @@ class ModelConfig(Config):
                 center_x = self.deflector_center_ra
                 center_y = self.deflector_center_dec
                 try:
-                    theta_E_init = self.settings["lens_options"]["initial_guesses"][i]["theta_E"]
+                    theta_E_init = self.settings["lens_options"]["initial_guesses"][i][
+                        "theta_E"
+                    ]
                 except (NameError, KeyError):
                     theta_E_init = 1.0
 
@@ -1866,7 +1867,9 @@ class ModelConfig(Config):
 
         if "initial_guesses" in self.settings[component + "_options"].keys():
             new_init_dict_list = deepcopy(init_dict_list)
-            for model_index, init_dict in self.settings[component + "_options"]["initial_guesses"].items():
+            for model_index, init_dict in self.settings[component + "_options"][
+                "initial_guesses"
+            ].items():
                 new_init_dict_list[int(model_index)].update(init_dict)
 
         return new_init_dict_list

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -118,13 +118,19 @@ class ModelConfig(Config):
                 del self.settings[f"{opt}_option"]
 
         self.guess_params = {}
-        for component in ["lens", "source_light", "lens_light", "ps"]:
+        for component in ["lens", "source_light", "lens_light"]:
             try:
                 self.guess_params[component] = deepcopy(
                     self.settings["guess_params"][component]
                 )
             except (NameError, KeyError):
                 self.guess_params[component] = None
+
+        if (
+            "ps" in self.settings["guess_params"].keys() or
+            "point_source" in self.settings["guess_params"].keys()
+        ):
+            raise ValueError("Initial point source parameter values should be provided in point_source_options instead of guess_params")
 
     @property
     def lens_name(self):

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -117,20 +117,6 @@ class ModelConfig(Config):
                 )
                 del self.settings[f"{opt}_option"]
 
-        self.guess_params = {}
-        for component in ["lens", "source_light", "lens_light"]:
-            try:
-                self.guess_params[component] = deepcopy(
-                    self.settings["guess_params"][component]
-                )
-            except (NameError, KeyError):
-                self.guess_params[component] = None
-
-        if (
-            "ps" in self.settings["guess_params"].keys() or
-            "point_source" in self.settings["guess_params"].keys()
-        ):
-            raise ValueError("Initial point source parameter values should be provided in point_source_options instead of guess_params")
 
     @property
     def lens_name(self):
@@ -1219,7 +1205,7 @@ class ModelConfig(Config):
                 center_x = self.deflector_center_ra
                 center_y = self.deflector_center_dec
                 try:
-                    theta_E_init = self.settings["guess_params"]["lens"][i]["theta_E"]
+                    theta_E_init = self.settings["lens_options"]["initial_guesses"][i]["theta_E"]
                 except (NameError, KeyError):
                     theta_E_init = 1.0
 
@@ -1865,7 +1851,7 @@ class ModelConfig(Config):
 
     def update_initial_guesses(self, component, init_dict_list):
         """Update the default initial parameter values with those provided by the user
-        in the config file as guess_params.
+        in the config file.
 
         :param component: name of the model component for which the initial parameter values
           will be updated
@@ -1876,13 +1862,12 @@ class ModelConfig(Config):
         :return: a modified list of dictionaries containing the updated initial parameter values
         :rtype: `list` of `dict`
         """
-        assert component in ["lens", "lens_light", "source_light"]
-        new_init_dict_list = deepcopy(init_dict_list)
+        assert component in ["lens", "lens_light", "source_light", "point_source"]
 
-        if self.guess_params[component] is not None:
-            for model_index, init_dict in self.guess_params[component].items():
-                model_index = int(model_index)
-                new_init_dict_list[model_index].update(init_dict)
+        if "initial_guesses" in self.settings[component + "_options"].keys():
+            new_init_dict_list = deepcopy(init_dict_list)
+            for model_index, init_dict in self.settings[component + "_options"]["initial_guesses"].items():
+                new_init_dict_list[int(model_index)].update(init_dict)
 
         return new_init_dict_list
 

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1875,6 +1875,7 @@ class ModelConfig(Config):
 
         if self.guess_params[component] is not None:
             for model_index in self.guess_params[component].keys():
+                model_index = int(model_index)
                 new_init_dict_list[model_index].update(
                     self.guess_params[component][model_index]
                 )

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1869,7 +1869,9 @@ class ModelConfig(Config):
             for model_index, init_dict in self.settings[component + "_options"]["initial_guesses"].items():
                 new_init_dict_list[int(model_index)].update(init_dict)
 
-        return new_init_dict_list
+            return new_init_dict_list
+        else:
+            return init_dict_list
 
     def update_uniform_priors(self, component, lower_dict_list, upper_dict_list):
         """Update the default uniform prior bounds with those provided by the user in

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -1874,11 +1874,9 @@ class ModelConfig(Config):
         new_init_dict_list = deepcopy(init_dict_list)
 
         if self.guess_params[component] is not None:
-            for model_index in self.guess_params[component].keys():
+            for model_index, init_dict in self.guess_params[component].items():
                 model_index = int(model_index)
-                new_init_dict_list[model_index].update(
-                    self.guess_params[component][model_index]
-                )
+                new_init_dict_list[model_index].update(init_dict)
 
         return new_init_dict_list
 

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -364,7 +364,9 @@ class Recipe(object):
                 # set lens parameter values to guess values, if provided
                 if "initial_guesses" in self._config.settings["lens_options"].keys():
                     param_list = []
-                    for index, params in self._config.settings["lens_options"]["initial_guesses"].items():
+                    for index, params in self._config.settings["lens_options"][
+                        "initial_guesses"
+                    ].items():
                         param_list.append(
                             [index, list(params.keys()), list(params.values())]
                         )

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -65,14 +65,7 @@ class Recipe(object):
 
         self._thread_count = thread_count
 
-        self.guess_params = {}
-        for component in ["lens", "source", "lens_light", "ps"]:
-            try:
-                self.guess_params[component] = deepcopy(
-                    config.settings["guess_params"][component]
-                )
-            except (NameError, KeyError):
-                self.guess_params[component] = None
+        self.guess_params = config.guess_params
 
     def get_recipe(self, kwargs_data_joint=None, recipe_name="galaxy-quasar"):
         """Get `fitting_kwargs_list` according to the requested `recipe`.

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -364,7 +364,7 @@ class Recipe(object):
                 # set lens parameter values to guess values, if provided
                 if "initial_guesses" in self._config.settings["lens_options"].keys():
                     param_list = []
-                    for index, params in self._config.settings["lens_options"].items():
+                    for index, params in self._config.settings["lens_options"]["initial_guesses"].items():
                         param_list.append(
                             [index, list(params.keys()), list(params.values())]
                         )

--- a/dolphin/processor/recipe.py
+++ b/dolphin/processor/recipe.py
@@ -65,8 +65,6 @@ class Recipe(object):
 
         self._thread_count = thread_count
 
-        self.guess_params = config.guess_params
-
     def get_recipe(self, kwargs_data_joint=None, recipe_name="galaxy-quasar"):
         """Get `fitting_kwargs_list` according to the requested `recipe`.
 
@@ -364,9 +362,9 @@ class Recipe(object):
                 ]
 
                 # set lens parameter values to guess values, if provided
-                if self.guess_params["lens"] is not None:
+                if "initial_guesses" in self._config.settings["lens_options"].keys():
                     param_list = []
-                    for index, params in self.guess_params["lens"].items():
+                    for index, params in self._config.settings["lens_options"].items():
                         param_list.append(
                             [index, list(params.keys()), list(params.values())]
                         )

--- a/io_directory_example/settings/lens_system1_config.yaml
+++ b/io_directory_example/settings/lens_system1_config.yaml
@@ -19,6 +19,11 @@ lens_options:
   limit_mass_q_from_light: 0
   # optional constraint on the light axis ratio to be smaller
   # than that of the mass, i.e., imposes q_M > q_L - limit_mass_q_from_light.
+  initial_guesses:
+    0:
+      theta_E: 1.2
+      e1: 0.05
+      e2: -0.05
 
 lens_light_options:
   fix: {0: {n_sersic: 4.}}   # fix n_sersic to 4, for 0-th light profile
@@ -58,13 +63,6 @@ kwargs_model:
 
 numeric_options:
   supersampling_factor: [3] # list specifying for each band
-
-guess_params:
-  lens:
-    0:
-      theta_E: 1.2
-      e1: 0.05
-      e2: -0.05
 
 mask:
   centroid_offset: [[0., 0]]

--- a/io_directory_example/settings/lens_system4_config.yaml
+++ b/io_directory_example/settings/lens_system4_config.yaml
@@ -16,6 +16,11 @@ lens_options:
   limit_mass_q_from_light: 0
   # optional constraint on the light axis ratio to be smaller
   # than that of the mass, i.e., imposes q_M > q_L - limit_mass_q_from_light.
+  initial_guesses:
+    0:
+      theta_E: 1.2
+      e1: 0.05
+      e2: -0.05
 
 lens_light_options:
   fix: {0: {n_sersic: 4.}}   # fix n_sersic to 4, for 0-th light profile
@@ -53,13 +58,6 @@ fitting:
 
 numeric_options:
   supersampling_factor: [3] # list specifying for each band
-
-guess_params:
-  lens:
-    0:
-      theta_E: 1.2
-      e1: 0.05
-      e2: -0.05
 
 mask:
   centroid_offset: [[0., 0]]

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -1058,7 +1058,7 @@ class TestModelConfig(object):
         init_dict_list = [{"theta_E": 0.1, "e1": 0.1, "e2": 0.1}]
 
         # Default initial values should be updated to match the ones given in yaml settings
-        updated_init_dict_list = self.config1.update_initial_guesses(
+        updated_init_dict_list = self.config_1.update_initial_guesses(
             "lens", init_dict_list
         )
         assert updated_init_dict_list == [{"theta_E": 1.2, "e1": 0.05, "e2": -0.05}]
@@ -1067,23 +1067,23 @@ class TestModelConfig(object):
         config1 = deepcopy(self.config_1)
 
         # Check that a warning is raised when initial value is greater than upper bound
-        config1.guess_params["lens"]["0"]["e1"] = 0.6
+        config1.guess_params["lens"][0]["e1"] = 0.6
         with pytest.warns(UserWarning):
-            config1.get_lens_model_list()
+            config1.get_lens_model_params()
 
         # Check that a warning is raised when initial value is less than lower bound
-        config1.guess_params["lens"]["0"]["e1"] = -0.6
+        config1.guess_params["lens"][0]["e1"] = -0.6
         with pytest.warns(UserWarning):
-            config1.get_lens_model_list()
+            config1.get_lens_model_params()
 
-        # Check that a warning is not raised if the parameter is fixed, even out of bounds
+        # Check that a warning is not raised if the parameter is fixed, even if out of bounds
         config3 = deepcopy(self.config_3)
-        config3.settings["lens_options"]["fix"]["0"]["gamma"] = 0.5
+        config3.settings["lens_options"]["fix"][0]["gamma"] = -0.5
         with warnings.catch_warnings():
             # Promote warning to error, which should not be raised
             warnings.simplefilter("error")
 
-            config3.get_lens_model_list()
+            config3.get_lens_model_params()
 
     def test_get_psf_supersampling_factor(self):
         """Test `get_psf_supersampling_factor` method."""

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -1058,7 +1058,9 @@ class TestModelConfig(object):
         init_dict_list = [{"theta_E": 0.1, "e1": 0.1, "e2": 0.1}]
 
         # Default initial values should be updated to match the ones given in yaml settings
-        updated_init_dict_list = self.config1.update_initial_guesses("lens", init_dict_list)
+        updated_init_dict_list = self.config1.update_initial_guesses(
+            "lens", init_dict_list
+        )
         assert updated_init_dict_list == [{"theta_E": 1.2, "e1": 0.05, "e2": -0.05}]
 
     def test_check_init_params_in_bounds(self):
@@ -1082,8 +1084,6 @@ class TestModelConfig(object):
             warnings.simplefilter("error")
 
             config3.get_lens_model_list()
-
-
 
     def test_get_psf_supersampling_factor(self):
         """Test `get_psf_supersampling_factor` method."""

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -822,6 +822,8 @@ class TestModelConfig(object):
         }
 
         config1 = deepcopy(self.config_1)
+        for component in ["lens", "source_light", "lens_light", "ps"]:
+            config1.guess_params[component] = None
         config1.settings["model"]["lens"] = ["FLEXION"]
         params1 = config1.get_lens_model_params()
         assert params1[0][0] == {"g1": 0, "g2": 0, "g3": 0, "g4": 0}

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -155,9 +155,19 @@ class TestModelConfig(object):
         pass
 
     def test_init(self):
-        settings = self.config_1.settings
-
+        settings = deepcopy(self.config_1.settings)
         ModelConfig(self.config_1.lens_name, settings=settings)
+
+        # Point source initial parameters should be passed in through point_source_options
+        # instead of guess_params
+        settings["guess_params"]["ps"] = {}
+        with pytest.raises(ValueError):
+            ModelConfig(self.config_1.lens_name, settings=settings)
+
+        del settings["guess_params"]["ps"]
+        settings["guess_params"]["point_source"] = {}
+        with pytest.raises(ValueError):
+            ModelConfig(self.config_1.lens_name, settings=settings)
 
     def test_pixel_size(self):
         """Test the `pixel_size` property."""

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.testing as npt
 import os
 from pathlib import Path
+import warnings
 
 from dolphin.processor.config import Config
 from dolphin.processor.config import ModelConfig
@@ -1051,6 +1052,38 @@ class TestModelConfig(object):
 
         with pytest.raises(AssertionError):
             self.config_3.fill_in_fixed_from_settings("invalid", fixed)
+
+    def test_update_initial_guesses(self):
+        """Test `update_initial_guesses` method."""
+        init_dict_list = [{"theta_E": 0.1, "e1": 0.1, "e2": 0.1}]
+
+        # Default initial values should be updated to match the ones given in yaml settings
+        updated_init_dict_list = self.config1.update_initial_guesses("lens", init_dict_list)
+        assert updated_init_dict_list == [{"theta_E": 1.2, "e1": 0.05, "e2": -0.05}]
+
+    def test_check_init_params_in_bounds(self):
+        config1 = deepcopy(self.config_1)
+
+        # Check that a warning is raised when initial value is greater than upper bound
+        config1.guess_params["lens"]["0"]["e1"] = 0.6
+        with pytest.warns(UserWarning):
+            config1.get_lens_model_list()
+
+        # Check that a warning is raised when initial value is less than lower bound
+        config1.guess_params["lens"]["0"]["e1"] = -0.6
+        with pytest.warns(UserWarning):
+            config1.get_lens_model_list()
+
+        # Check that a warning is not raised if the parameter is fixed, even out of bounds
+        config3 = deepcopy(self.config_3)
+        config3.settings["lens_options"]["fix"]["0"]["gamma"] = 0.5
+        with warnings.catch_warnings():
+            # Promote warning to error, which should not be raised
+            warnings.simplefilter("error")
+
+            config3.get_lens_model_list()
+
+
 
     def test_get_psf_supersampling_factor(self):
         """Test `get_psf_supersampling_factor` method."""

--- a/test/test_processor/test_config.py
+++ b/test/test_processor/test_config.py
@@ -158,17 +158,6 @@ class TestModelConfig(object):
         settings = deepcopy(self.config_1.settings)
         ModelConfig(self.config_1.lens_name, settings=settings)
 
-        # Point source initial parameters should be passed in through point_source_options
-        # instead of guess_params
-        settings["guess_params"]["ps"] = {}
-        with pytest.raises(ValueError):
-            ModelConfig(self.config_1.lens_name, settings=settings)
-
-        del settings["guess_params"]["ps"]
-        settings["guess_params"]["point_source"] = {}
-        with pytest.raises(ValueError):
-            ModelConfig(self.config_1.lens_name, settings=settings)
-
     def test_pixel_size(self):
         """Test the `pixel_size` property."""
         self.config_3.settings["pixel_size"] = [0.04, 0.08]
@@ -833,8 +822,7 @@ class TestModelConfig(object):
         }
 
         config1 = deepcopy(self.config_1)
-        for component in ["lens", "source_light", "lens_light", "ps"]:
-            config1.guess_params[component] = None
+        del config1.settings["lens_options"]["initial_guesses"]
         config1.settings["model"]["lens"] = ["FLEXION"]
         params1 = config1.get_lens_model_params()
         assert params1[0][0] == {"g1": 0, "g2": 0, "g3": 0, "g4": 0}
@@ -1077,12 +1065,12 @@ class TestModelConfig(object):
         config1 = deepcopy(self.config_1)
 
         # Check that a warning is raised when initial value is greater than upper bound
-        config1.guess_params["lens"][0]["e1"] = 0.6
+        config1.settings["lens_options"]["initial_guesses"][0]["e1"] = 0.6
         with pytest.warns(UserWarning):
             config1.get_lens_model_params()
 
         # Check that a warning is raised when initial value is less than lower bound
-        config1.guess_params["lens"][0]["e1"] = -0.6
+        config1.settings["lens_options"]["initial_guesses"][0]["e1"] = -0.6
         with pytest.warns(UserWarning):
             config1.get_lens_model_params()
 


### PR DESCRIPTION
1. [Documentation](https://github.com/ajshajib/dolphin/blob/4c2cbf2d7dbdc2afa2b9a8c95c290b38dc4d0822/CONFIG_OPTIONS.rst?plain=1#L547) for `Guess parameters` suggests that users can modify initial parameter values. However, this feature did not actually work for any parameter other than the einstein radius of the zeroth deflector model. This PR expands this feature to work for any parameter in any model by deprecating the `guess_params` field in the yaml settings and introducing the `initial_guesses` field which should be placed in `lens_options` etc.
2. This PR also adds a check after initial parameter values and bounds have been finalized so that the user is notified by a warning whenever a parameter has its initial value set outside of the bounds.
3. Many documentation improvements.