### PR TITLE
Implement the saving and loading of BIC and various docstring fixes

### DIFF
--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -4,6 +4,7 @@ __author__ = "ajshajib"
 
 import matplotlib.pyplot as plt
 import numpy as np
+import warnings
 from lenstronomy import __version__ as _lenstronomy_version
 from lenstronomy.Data.coord_transforms import Coordinates
 from lenstronomy.LensModel.lens_model import LensModel
@@ -32,6 +33,7 @@ class Output(Processor):
 
         self._fit_output = None
         self._kwargs_result = None
+        self._bic = None
         self._model_settings = None
         self._posterior_samples = None
         self._params_sampled = None
@@ -72,6 +74,27 @@ class Output(Processor):
             )
         else:
             return self._kwargs_result
+
+    @property
+    def bayesian_information_criterion(self):
+        """The `bic` after running a model by calling
+        `lenstronomy.Workflow.fitting_sequence.FittingSequence.bic`.
+
+        :return: `bic` value
+        :rtype: `dict`
+        """
+        if self._bic is None:
+            raise ValueError(
+                "Model output not specified!"
+                "Load an output using the `load_output()`"
+                "method!"
+            )
+        elif self._bic == "not_available":
+            warnings.warn(
+                "Loading an outdated save file; Bayesian information criterion not available."
+            )
+
+        return self._bic
 
     @property
     def model_settings(self):
@@ -185,6 +208,7 @@ class Output(Processor):
         output = self.file_system.load_output(lens_name, model_id)
 
         self._model_settings = output["settings"]
+        self._bic = output["bic"]
         self._kwargs_result = output["kwargs_result"]
         self._fit_output = output["fit_output"]
         self._multi_band_list_out = output["multi_band_list_out"]
@@ -334,7 +358,7 @@ class Output(Processor):
         :type source_vmax: `float` or `int` or `None`
         :param print_results: if `True`, prints the `kwargs_result` dictionary
         :type print_results: `bool`
-        :param show_source_light: if `True`, replaces convergence plot with source light convolved lens decomposition plot and also replaces the magnification plot with the source-light subtracted data plot
+        :param show_source_light: if `True`, replaces convergence plot with source light convolved lens decomposition plot and also replaces the magnification plot with the lens-light subtracted data plot
         :type show_source_light: `bool`
         :param kwargs_data_plot: kwargs for the data plot, see :func: `lenstronomy.Plots.model_plot.ModelPlot.data_plot()` for available keywords.
         :type kwargs_data_plot: `dict`
@@ -433,7 +457,7 @@ class Output(Processor):
         else:
             kwargs_subtract_lens_light_plot.setdefault("kwargs_title", {})
             kwargs_subtract_lens_light_plot["kwargs_title"].setdefault(
-                "title", "Data - Lens Light"
+                "text", "Data - Lens Light"
             )
             model_plot.subtract_from_data_plot(
                 ax=axes[1, 1],
@@ -446,7 +470,7 @@ class Output(Processor):
 
             kwargs_reconstructed_source_plot.setdefault("kwargs_title", {})
             kwargs_reconstructed_source_plot["kwargs_title"].setdefault(
-                "title", "Reconstructed Source"
+                "text", "Reconstructed Lensed Source"
             )
             model_plot.decomposition_plot(
                 ax=axes[1, 2],
@@ -818,7 +842,7 @@ class Output(Processor):
         :return: `ImSim` instance
         :rtype: `lenstronomy.ImSim.im_sim.ImSim`
         """
-        config = ModelConfig(lens_name=lens_name, settings=self._model_settings)
+        config = ModelConfig(lens_name=lens_name, file_system=self.file_system, settings=self._model_settings)
 
         # kwargs_numerics = config.get_kwargs_numerics()
         kwargs_model = config.get_kwargs_model()

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -842,7 +842,11 @@ class Output(Processor):
         :return: `ImSim` instance
         :rtype: `lenstronomy.ImSim.im_sim.ImSim`
         """
-        config = ModelConfig(lens_name=lens_name, file_system=self.file_system, settings=self._model_settings)
+        config = ModelConfig(
+            lens_name=lens_name,
+            file_system=self.file_system,
+            settings=self._model_settings,
+        )
 
         # kwargs_numerics = config.get_kwargs_numerics()
         kwargs_model = config.get_kwargs_model()

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -2,9 +2,10 @@
 
 __author__ = "ajshajib"
 
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
-import warnings
 from lenstronomy import __version__ as _lenstronomy_version
 from lenstronomy.Data.coord_transforms import Coordinates
 from lenstronomy.LensModel.lens_model import LensModel

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -81,7 +81,7 @@ class Output(Processor):
         """The `bic` after running a model by calling
         `lenstronomy.Workflow.fitting_sequence.FittingSequence.bic`.
 
-        :return: `bic` value
+        :return: BIC value
         :rtype: `dict`
         """
         if self._bic is None:

--- a/dolphin/analysis/output.py
+++ b/dolphin/analysis/output.py
@@ -78,7 +78,7 @@ class Output(Processor):
 
     @property
     def bayesian_information_criterion(self):
-        """The `bic` after running a model by calling
+        """The BIC value after running a model by calling
         `lenstronomy.Workflow.fitting_sequence.FittingSequence.bic`.
 
         :return: BIC value

--- a/dolphin/processor/config.py
+++ b/dolphin/processor/config.py
@@ -63,7 +63,7 @@ class ModelConfig(Config):
     def __init__(self, lens_name, file_system=None, io_directory=None, settings=None):
         """Initiate a Model Config object. If the file path is given, `settings` will be
         loaded from it. Otherwise, the `settings` can be loaded/reloaded later with the
-        `load_settings_from_file` method.
+        `load_settings_from_yaml` method.
 
         :param lens_name: name of the lens system
         :type lens_name: `str`
@@ -72,7 +72,7 @@ class ModelConfig(Config):
         :param io_directory: path to the input-output directory
         :type io_directory: `str` or `None`
         :param settings: a dictionary containing settings. If both `file`
-            and `settings` are provided, `file` will be prioritized.
+            and `settings` are provided, `settings` will be prioritized.
         :type settings: `dict` or `None`
         """
         super().__init__()

--- a/dolphin/processor/core.py
+++ b/dolphin/processor/core.py
@@ -112,11 +112,13 @@ class Processor:
 
             fit_output = fitting_sequence.fit_sequence(fitting_kwargs_list)
             kwargs_result = fitting_sequence.best_fit(bijective=False)
+            bic = fitting_sequence.bic
             multi_band_list_out = fitting_sequence.multi_band_list
 
             output = {
                 "settings": config.settings,
                 "kwargs_result": kwargs_result,
+                "bic": bic,
                 "fit_output": fit_output,
                 "multi_band_list_out": multi_band_list_out,
                 "dolphin_version": __version__,

--- a/dolphin/processor/files.py
+++ b/dolphin/processor/files.py
@@ -225,6 +225,9 @@ class FileSystem:
             f.attrs["settings"] = json.dumps(
                 self.encode_numpy_arrays(output["settings"]), ensure_ascii=False
             )
+            f.attrs["bic"] = json.dumps(
+                self.encode_numpy_arrays(output["bic"]), ensure_ascii=False
+            )
             f.attrs["kwargs_result"] = json.dumps(
                 self.encode_numpy_arrays(output["kwargs_result"]), ensure_ascii=False
             )
@@ -353,6 +356,13 @@ class FileSystem:
         with h5py.File(load_file, "r") as f:
             settings = self.decode_numpy_arrays(json.loads(str(f.attrs["settings"])))
 
+            # Maintain backwards compatibility by setting bic=nan if loading an output
+            # that was saved before bic was implemented
+            try:
+                bic = self.decode_numpy_arrays(json.loads(str(f.attrs["bic"])))
+            except KeyError:
+                bic = "not_available"
+
             kwargs_result = self.decode_numpy_arrays(
                 json.loads(str(f.attrs["kwargs_result"]))
             )
@@ -421,6 +431,7 @@ class FileSystem:
 
             output = {
                 "settings": settings,
+                "bic": bic,
                 "kwargs_result": kwargs_result,
                 "fit_output": fit_output,
                 "multi_band_list_out": multi_band_list_out,

--- a/test/test_analysis/test_output.py
+++ b/test/test_analysis/test_output.py
@@ -47,6 +47,9 @@ class TestOutput:
             _ = self.output.kwargs_result
 
         with pytest.raises(ValueError):
+            _ = self.output.bayesian_information_criterion
+
+        with pytest.raises(ValueError):
             _ = self.output.model_settings
 
         assert self.output.posterior_samples == []
@@ -112,6 +115,9 @@ class TestOutput:
         assert self.output.lenstronomy_version == lenstronomy.__version__
         assert self.output.jaxtronomy_version == "0.1.0"
         assert self.output.bayesian_information_criterion == 5000
+
+        self.output.load_output("lens_system2", "example")
+        assert np.isnan(self.output.bayesian_information_criterion)
 
     def test_load_output_version_warnings(self, capsys):
         """Test that correct warnings are printed when versions mismatch.

--- a/test/test_analysis/test_output.py
+++ b/test/test_analysis/test_output.py
@@ -117,7 +117,7 @@ class TestOutput:
         assert self.output.bayesian_information_criterion == 5000
 
         self.output.load_output("lens_system2", "example")
-        assert np.isnan(self.output.bayesian_information_criterion)
+        assert self.output.bayesian_information_criterion == "not_available"
 
     def test_load_output_version_warnings(self, capsys):
         """Test that correct warnings are printed when versions mismatch.

--- a/test/test_analysis/test_output.py
+++ b/test/test_analysis/test_output.py
@@ -89,6 +89,7 @@ class TestOutput:
         save_dict = {
             "settings": {"some": "settings"},
             "kwargs_result": {"0": None, "1": "str", "2": [3, 4]},
+            "bic": 5000,
             "fit_output": [
                 ["emcee", [[2, 2], [3, 3]], ["param1", "param2"], [0.5, 0.2]]
             ],
@@ -110,6 +111,7 @@ class TestOutput:
         assert self.output.dolphin_version == dolphin.__version__
         assert self.output.lenstronomy_version == lenstronomy.__version__
         assert self.output.jaxtronomy_version == "0.1.0"
+        assert self.output.bayesian_information_criterion == 5000
 
     def test_load_output_version_warnings(self, capsys):
         """Test that correct warnings are printed when versions mismatch.
@@ -120,6 +122,7 @@ class TestOutput:
         save_dict = {
             "settings": {"some": "settings"},
             "kwargs_result": {"0": None, "1": "str", "2": [3, 4]},
+            "bic": 5000,
             "fit_output": [
                 ["emcee", [[2, 2], [3, 3]], ["param1", "param2"], [0.5, 0.2]]
             ],
@@ -165,6 +168,7 @@ class TestOutput:
         save_dict = {
             "settings": {"some": "settings"},
             "kwargs_result": {"0": None, "1": "str", "2": [3, 4]},
+            "bic": 5000,
             "fit_output": [
                 ["emcee", [[2, 2], [3, 3]], ["param1", "param2"], [0.5, 0.2]]
             ],
@@ -396,6 +400,7 @@ class TestOutput:
         save_dict = {
             "settings": {"some": "settings"},
             "kwargs_result": {"0": None},
+            "bic": 5000,
             "fit_output": [
                 [
                     "Nautilus",

--- a/test/test_processor/test_files.py
+++ b/test/test_processor/test_files.py
@@ -133,6 +133,7 @@ class TestFileSystem:
         save_dict = {
             "settings": {"some": ["settings"]},
             "kwargs_result": {"0": 1, "1": "str", "2": [3, 4]},
+            "bic": 5000,
             "fit_output": [
                 [
                     "PSO",


### PR DESCRIPTION
1. The Bayesian information criterion is useful to have when comparing models and determining the optimal shapelet n_max (e.g. [Williams et al 2025](https://www.aanda.org/articles/aa/abs/2025/11/aa54359-25/aa54359-25.html)). Thus, this PR implements the saving and loading of the bic values.
2. Calling `Output.get_im_sim()` for a lens whose config contains mask settings will result in an error, since `config.get_masks()` requires `file_system` to be present. This bug is not caught during tests since `lens_system2` does not have any mask settings. This PR fixes this bug.
3. docstring fixes